### PR TITLE
DAP tag reorganization

### DIFF
--- a/assets/client/src/index.js
+++ b/assets/client/src/index.js
@@ -7,6 +7,8 @@ import * as serviceWorker from './serviceWorker';
 import { useTracking } from './useTracking'
 import ReactGA from 'react-ga'
 
+ReactGA.initialize('_fed_an_ua_tag')
+
 const getRoutes = () => {
   return IndexRoutes.map((prop, i) => {
     if (prop.redirect) {

--- a/assets/client/src/index.js
+++ b/assets/client/src/index.js
@@ -7,13 +7,6 @@ import * as serviceWorker from './serviceWorker';
 import { useTracking } from './useTracking'
 import ReactGA from 'react-ga'
 
-ReactGA.initialize('_fed_an_ua_tag',
-  {
-    gaAddress:
-      "https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=GSA"
-  }
-)
-
 const getRoutes = () => {
   return IndexRoutes.map((prop, i) => {
     if (prop.redirect) {
@@ -33,7 +26,7 @@ const getRoutes = () => {
 };
 
 const Application = () => {
-  useTracking('_fed_an_ua_tag')
+  useTracking()
 
   return (
     <Switch>{getRoutes()}</Switch>

--- a/assets/client/src/useTracking.js
+++ b/assets/client/src/useTracking.js
@@ -2,27 +2,17 @@ import { useEffect } from 'react'
 import { useLocation } from 'react-router-dom'
 import ReactGA from 'react-ga'
 
-export const useTracking = (GA_MEASUREMENT_ID) => {
+export const useTracking = () => {
 
-// send pathname on SPA routed pages
+  ReactGA.initialize('_fed_an_ua_tag')
+
+  // send pathname on SPA routed pages
   let location = useLocation()
 
-  useEffect(
-    () => {
-      ReactGA.ga('send', 'pageview', location.pathname);
+  useEffect(() => {
+      window.ga('set', 'page', location.pathname);
+      window.ga('send', 'pageview');
     },
     [location]
   )
-
-// inject script tag into all other pages
-  useEffect(() => {
-    const script = document.createElement("script");
-
-    script.async = true;
-    script.type = "text/javascript"
-    script.id = GA_MEASUREMENT_ID
-    script.src = "https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=GSA";
-
-    document.body.appendChild(script)
-  },[])
 }

--- a/assets/client/src/useTracking.js
+++ b/assets/client/src/useTracking.js
@@ -4,8 +4,6 @@ import ReactGA from 'react-ga'
 
 export const useTracking = () => {
 
-  ReactGA.initialize('_fed_an_ua_tag')
-
   // send pathname on SPA routed pages
   let location = useLocation()
 


### PR DESCRIPTION
Tag created and recognized in Google Tag Assistant (what DAP uses) and collecting in network.
* removed building of script tag on every page
* set ReactGA initialization to property ID only, rm address source
* no source being specified (local or centrally hosted)
