### PR TITLE
manual decertification: changes to terms and challenge access

### DIFF
--- a/lib/challenge_gov/accounts.ex
+++ b/lib/challenge_gov/accounts.ex
@@ -634,6 +634,8 @@ defmodule ChallengeGov.Accounts do
   defp maybe_update_request_renewal(struct, user) do
     if user.renewal_request == "activation" do
       Ecto.Changeset.put_change(struct, :renewal_request, nil)
+    else
+      struct
     end
   end
 


### PR DESCRIPTION
terms nullified and access to challenges revoked on manual status editing to "decertified"
