### PR TITLE
pending user: add cert on approval, exclude from cert info showing

### DIFF
--- a/lib/challenge_gov/accounts.ex
+++ b/lib/challenge_gov/accounts.ex
@@ -623,8 +623,8 @@ defmodule ChallengeGov.Accounts do
       |> Repo.transaction()
 
     case result do
-      {:ok, _result} ->
-        maybe_certify_user(user, previous_status, originator, remote_ip)
+      {:ok, %{user: user}} ->
+        maybe_certify_user(user, originator, remote_ip)
         {:ok, user}
 
       {:error, _type, changeset, _changes} ->
@@ -640,7 +640,7 @@ defmodule ChallengeGov.Accounts do
     end
   end
 
-  defp maybe_certify_user(user, "pending", approver, approver_remote_ip) do
+  defp maybe_certify_user(user, approver, approver_remote_ip) do
     # check for certification history since user could have been active before
     with {:error, :no_log_found} <- CertificationLogs.get_current_certification(user) do
       CertificationLogs.track(%{
@@ -655,10 +655,6 @@ defmodule ChallengeGov.Accounts do
         expires_at: CertificationLogs.calulate_expiry()
       })
     end
-  end
-
-  defp maybe_certify_user(_user, _previous_status, _approver, _approver_remote_ip) do
-    # NO OP - was not a pending user
   end
 
   @doc """

--- a/lib/challenge_gov/certification_logs.ex
+++ b/lib/challenge_gov/certification_logs.ex
@@ -102,7 +102,7 @@ defmodule ChallengeGov.CertificationLogs do
   @doc """
   calculate certification expiry based on decertification env var
   """
-  def calulate_expiry() do
+  def calulate_expiry do
     decertification_interval = Security.decertify_days()
     expiry = Timex.shift(DateTime.utc_now(), days: decertification_interval)
     DateTime.truncate(expiry, :second)
@@ -111,7 +111,7 @@ defmodule ChallengeGov.CertificationLogs do
   @doc """
   Stream certification log for CSV download
   """
-  def stream_all_records() do
+  def stream_all_records do
     CertificationLog
     |> order_by([r], asc: r.id)
     |> Repo.all()

--- a/lib/challenge_gov/certification_logs.ex
+++ b/lib/challenge_gov/certification_logs.ex
@@ -16,6 +16,30 @@ defmodule ChallengeGov.CertificationLogs do
     |> Repo.insert()
   end
 
+  def certify_user_with_approver(user, approver, approver_remote_ip) do
+    track(%{
+      approver_id: approver.id,
+      approver_role: approver.role,
+      approver_identifier: approver.email,
+      approver_remote_ip: approver_remote_ip,
+      user_id: user.id,
+      user_role: user.role,
+      user_identifier: user.email,
+      certified_at: Timex.now(),
+      expires_at: calulate_expiry()
+    })
+  end
+
+  def certification_request(conn, user) do
+    track(%{
+      user_id: user.id,
+      user_role: user.role,
+      user_identifier: user.email,
+      user_remote_ip: Security.extract_remote_ip(conn),
+      requested_at: Timex.now()
+    })
+  end
+
   def check_for_expired_certifications do
     two_days_ago = Timex.shift(Timex.now(), days: -2)
 

--- a/lib/challenge_gov/certification_logs.ex
+++ b/lib/challenge_gov/certification_logs.ex
@@ -51,7 +51,7 @@ defmodule ChallengeGov.CertificationLogs do
   Get most current certification record by user id
   """
   def get_current_certification(user) do
-    case user.role == "solver" do
+    case user.role == "solver" or user.status == "pending" do
       true ->
         {:ok, %{}}
 

--- a/lib/web/controllers/admin/access_controller.ex
+++ b/lib/web/controllers/admin/access_controller.ex
@@ -36,13 +36,7 @@ defmodule Web.Admin.AccessController do
 
     with {:ok, user} <- Accounts.update_terms(current_user, params),
          {:ok, user} <- Accounts.update(user, %{renewal_request: "certification"}) do
-      CertificationLogs.track(%{
-        user_id: user.id,
-        user_role: user.role,
-        user_identifier: user.email,
-        user_remote_ip: Security.extract_remote_ip(conn),
-        requested_at: Timex.now()
-      })
+      CertificationLogs.certification_request(conn, user)
 
       conn
       |> put_flash(:info, "Success")

--- a/lib/web/controllers/admin/user_controller.ex
+++ b/lib/web/controllers/admin/user_controller.ex
@@ -120,17 +120,7 @@ defmodule Web.Admin.UserController do
               {:ok, certification}
 
             {:error, :no_log_found} ->
-              CertificationLogs.track(%{
-                approver_id: current_user.id,
-                approver_role: current_user.role,
-                approver_identifier: current_user.email,
-                approver_remote_ip: remote_ip,
-                user_id: user.id,
-                user_role: user.role,
-                user_identifier: user.email,
-                certified_at: Timex.now(),
-                expires_at: CertificationLogs.calulate_expiry()
-              })
+              CertificationLogs.certify_user_with_approver(user, current_user, remote_ip)
           end
 
         conn
@@ -226,17 +216,7 @@ defmodule Web.Admin.UserController do
         Accounts.update(user, get_recertify_update_params(user))
       end)
       |> Ecto.Multi.run(:certification_record, fn _repo, _changes ->
-        CertificationLogs.track(%{
-          approver_id: approver.id,
-          approver_role: approver.role,
-          approver_identifier: approver.email,
-          approver_remote_ip: approver_remote_ip,
-          user_id: user.id,
-          user_role: user.role,
-          user_identifier: user.email,
-          certified_at: Timex.now(),
-          expires_at: CertificationLogs.calulate_expiry()
-        })
+        CertificationLogs.certify_user_with_approver(user, approver, approver_remote_ip)
       end)
       |> Repo.transaction()
 

--- a/lib/web/templates/admin/user/show.html.eex
+++ b/lib/web/templates/admin/user/show.html.eex
@@ -70,7 +70,7 @@
                 <%= link("Suspend user", to: Routes.admin_user_path(@conn, :toggle, @user.id, action: "suspend"), method: :post, class: "btn btn-default") %>
                 <%= link("Revoke user", to: Routes.admin_user_path(@conn, :toggle, @user.id, action: "revoke"), method: :post, class: "btn btn-default") %>
               <% end %>
-              <%= if !Accounts.is_solver?(@user) do %>
+              <%= if !Accounts.is_solver?(@user) and !Accounts.is_pending?(@user) do %>
                 <p>
                   <%= Web.Admin.UserView.certification_info(@certification)%>
                 </p>


### PR DESCRIPTION
#### Changes
automatic recertification on activating a pending user
added pending users to no fly zone wrt viewing and creating certification
made certification logging functions in CertificationLogs
removed parens from fn with no attributes