### PR TITLE
Fetch archived challenges

### DIFF
--- a/assets/client/src/components/ChallengeAnnouncement.js
+++ b/assets/client/src/components/ChallengeAnnouncement.js
@@ -1,20 +1,37 @@
 import React from 'react';
 import moment from 'moment';
-import {formatDate, daysInMinutes} from "../helpers/phaseHelpers"
+import {formatDate, daysInMinutes, formatDateTime} from "../helpers/phaseHelpers"
 
 export const ChallengeAnnouncement = ({challenge}) => {
   const checkAnnouncementDate = ({announcement_datetime}) => {
     return moment().diff(announcement_datetime, 'minutes') <= daysInMinutes(14)
   }
 
-  return (    
-    checkAnnouncementDate(challenge) ? (
+  const renderAnnouncement = ({header, body}) => {
+    return (
       <div className="usa-alert usa-alert--info mb-3">
         <div className="usa-alert__body">
-          <h3 className="usa-alert__heading">Important update on {formatDate(challenge.announcement_datetime)}</h3>
-          <p className="usa-alert__text">{challenge.announcement}</p>
+          {header ? <h3 className="usa-alert__heading">{header}</h3> : null}
+          {body ? <p className="usa-alert__text">{body}</p> : null}
         </div>
       </div>
-    ) : null
+    )
+  }
+
+  const renderClosedBanner = ({is_closed, is_archived}) => {
+    if (is_archived) {
+      return renderAnnouncement({body: "This challenge is closed to submissions."})
+    } else if (is_closed) {
+      return renderAnnouncement({body: "This is an ongoing competition open to select winners only."})
+    }
+  }
+
+  return (
+    <>
+      {renderClosedBanner(challenge)}
+      {checkAnnouncementDate(challenge) ? 
+        renderAnnouncement({header: `Important update on ${formatDate(challenge.announcement_datetime)}`, body: challenge.announcement}) : null
+      }
+    </>
   )
 }

--- a/assets/client/src/components/ChallengeTile.js
+++ b/assets/client/src/components/ChallengeTile.js
@@ -8,12 +8,16 @@ import { ApiUrlContext } from '../ApiUrlContext'
 export const ChallengeTile = ({challenge, preview}) => {
   const { imageBase } = useContext(ApiUrlContext)
 
-  const renderTags = ({start_date, end_date, announcement_datetime}) => {
+  const renderTags = ({is_archived, start_date, end_date, announcement_datetime}) => {
     const startDateDiff = moment().diff(start_date, 'minutes')
     const endDateDiff = moment().diff(end_date, 'minutes')
     const announcementDateDiff = moment().diff(announcement_datetime, 'minutes')
 
     let tags = []
+
+    if (is_archived) {
+      tags.push(<div key={"archived"} className="usa-tag usa-tag--archived">Archived</div>)
+    }
 
     if (startDateDiff < 0) {
       tags.push(<div key={"coming_soon"} className="usa-tag usa-tag--coming-soon">Coming soon</div>)

--- a/assets/client/src/components/ChallengeTiles.js
+++ b/assets/client/src/components/ChallengeTiles.js
@@ -5,26 +5,41 @@ import { ChallengeTile } from "./ChallengeTile"
 
 export const ChallengeTiles = ({data, loading, isArchived, selectedYear, handleYearChange}) => {
 
-  const renderChallengeTiles = (challenges) => {
-    // TODO: Temporary showing of layout on chal details until the layout is moved
-    $(".top-banner").show()
-    $(".help-section").show()
-    $(".section-divider").show()
-    $(".footer").show()
+  const renderChallengeTiles = () => {
+    if (loading) {
+      return (
+        <div className="cards__loader-wrapper" aria-label="Loading active challenges">
+          {[1,2,3,4,5,6].map(numOfPlaceholders => (
+            <div key={numOfPlaceholders}>
+              <div className="card__loader--image"></div>
+              <div className="card__loader--text line-1"></div>
+              <div className="card__loader--text line-2"></div>
+              <div className="card__loader--text line-3"></div>
+            </div>
+          ))}
+        </div>
+      )
+    } else {
+      if (data.collection) {
+        if (data.collection.length > 0) {
+          return (
+            <div className="cards">
+              {data.collection.map(c => (
+                  <ChallengeTile key={c.id} challenge={c} />
+              ))}
+            </div>
+          )
+        }
 
-    if (challenges.collection) {
-      if (challenges.collection.length > 0) {
-        return challenges.collection.map(c => (
-          <ChallengeTile key={c.id} challenge={c} />
-        ))
-      }
-
-      if (challenges.collection.length == 0) {
-        return (
-          <p className="cards__none">
-            There are no current challenges. Please check back again soon!
-          </p>
-        )
+        if (data.collection.length == 0) {
+          return (
+            <div className="cards">
+              <p className="cards__none">
+                There are no current challenges. Please check back again soon!
+              </p>
+            </div>
+          )
+        }
       }
     }
   }
@@ -82,31 +97,11 @@ export const ChallengeTiles = ({data, loading, isArchived, selectedYear, handleY
 
   return (
     <section id="active-challenges" className="cards__section">
-      {loading
-        ? (
-          <div className="cards__loader-wrapper" aria-label="Loading active challenges">
-            {[1,2,3,4,5,6].map(numOfPlaceholders => (
-              <div key={numOfPlaceholders}>
-                <div className="card__loader--image"></div>
-                <div className="card__loader--text line-1"></div>
-                <div className="card__loader--text line-2"></div>
-                <div className="card__loader--text line-3"></div>
-              </div>
-            ))}
-          </div>
-        )
-        : (
-          <section className="cards__section">
-            {renderHeader()}
-            {renderSubHeader()}
-            {renderYearFilter()}
-            {renderSortText()}
-            <div className="cards">
-              {renderChallengeTiles(data)}
-            </div>
-          </section>
-        )
-      }
+      {renderHeader()}
+      {renderSubHeader()}
+      {renderYearFilter()}
+      {renderSortText()}
+      {renderChallengeTiles()}
     </section>
   )
 }

--- a/assets/client/src/components/ChallengeTiles.js
+++ b/assets/client/src/components/ChallengeTiles.js
@@ -3,7 +3,7 @@ import { Link } from "react-router-dom";
 import moment from "moment"
 import { ChallengeTile } from "./ChallengeTile"
 
-export const ChallengeTiles = ({data, loading}) => {
+export const ChallengeTiles = ({data, loading, isArchived, selectedYear, handleYearChange}) => {
 
   const renderChallengeTiles = (challenges) => {
     // TODO: Temporary showing of layout on chal details until the layout is moved
@@ -13,7 +13,6 @@ export const ChallengeTiles = ({data, loading}) => {
     $(".footer").show()
 
     if (challenges.collection) {
-
       if (challenges.collection.length > 0) {
         return challenges.collection.map(c => (
           <ChallengeTile key={c.id} challenge={c} />
@@ -26,6 +25,57 @@ export const ChallengeTiles = ({data, loading}) => {
             There are no current challenges. Please check back again soon!
           </p>
         )
+      }
+    }
+  }
+
+  const renderHeader = () => {
+    return (
+      <h2 className="mb-5">
+        {isArchived ? "Archived challenges" : "Active challenges"}
+      </h2>
+    )
+  }
+  
+  const renderSubHeader = () => {
+    return isArchived ?
+      (
+        <p>
+          Challenges on this page are either closed to submissions (completed) or only open to select winners of a pervious competition phase.
+        </p>
+      )
+      : null
+  }
+
+  const renderYearFilter = () => {
+    const startYear = 2009
+    const currentYear = moment().year()
+    const range = (start, stop, step) => Array.from({ length: (stop - start) / step + 1}, (_, i) => start + (i * step));
+
+    const years = range(currentYear, startYear, -1)
+
+    if (isArchived) {
+      return (
+        <div className="cards__year-filter">
+          <div>Filter by year:</div>
+          <select value={selectedYear} onChange={handleYearChange}>
+            {
+              years.map(year => {
+                return <option key={year}>{year}</option>
+              })
+            }
+          </select>
+        </div>
+      )
+    } 
+  }
+
+  const renderSortText = () => {
+    if (isArchived) {
+      return <p className="card__section--sort"><i>Challenges sorted by those most recently closed to open submissions</i></p>
+    } else {
+      if (data.collection && data.collection.length >= 1) {
+        return <p className="card__section--sort"><i>Challenges sorted by those closing soonest</i></p>
       }
     }
   }
@@ -47,11 +97,10 @@ export const ChallengeTiles = ({data, loading}) => {
         )
         : (
           <section className="cards__section">
-            <h2>Active challenges</h2>
-            {
-              (data.collection && data.collection.length >= 1) &&
-              <p className="card__section--sort">Challenges sorted by those closing soonest</p>
-            }
+            {renderHeader()}
+            {renderSubHeader()}
+            {renderYearFilter()}
+            {renderSortText()}
             <div className="cards">
               {renderChallengeTiles(data)}
             </div>

--- a/assets/client/src/helpers/stringHelpers.js
+++ b/assets/client/src/helpers/stringHelpers.js
@@ -1,8 +1,10 @@
 export const truncateString = (str, len) => {
-  if (str.length <= len) {
-    return str
+  if (str) {
+    if (str.length <= len) {
+      return str
+    }
+    return str.slice(0, len) + '...'
   }
-  return str.slice(0, len) + '...'
 }
 
 export default {

--- a/assets/client/src/pages/LandingPage.js
+++ b/assets/client/src/pages/LandingPage.js
@@ -8,13 +8,14 @@ export const LandingPage = () => {
   const [loadingState, setLoadingState] = useState(false)
 
   const { apiUrl } = useContext(ApiUrlContext)
+  const challengesPath = window.location.hash === "#/challenges/archived" ? "/api/challenges?archived=true" : "/api/challenges"
 
   $(".usa-hero").show()
 
   useEffect(() => {
     setLoadingState(true)
     axios
-      .get(apiUrl + "/api/challenges")
+      .get(apiUrl + challengesPath)
       .then(res => {
         setCurrentChallenges(res.data)
         setLoadingState(false)

--- a/assets/client/src/pages/LandingPage.js
+++ b/assets/client/src/pages/LandingPage.js
@@ -13,7 +13,17 @@ export const LandingPage = () => {
   const { apiUrl } = useContext(ApiUrlContext)
   const challengesPath = isArchived ? "/api/challenges?archived=true" : "/api/challenges"
 
-  $(".usa-hero").show()
+  // TODO: Temporary showing of layout on chal details until the layout is moved
+  if (isArchived) {
+    $(".top-banner").hide()
+    $(".usa-hero").hide()
+  } else {
+    $(".top-banner").show()
+    $(".usa-hero").show()
+  }
+  $(".help-section").show()
+  $(".section-divider").show()
+  $(".footer").show()
 
   useEffect(() => {
     let yearFilter = isArchived ? `&filter[year]=${selectedYear}` : ""

--- a/assets/client/src/pages/LandingPage.js
+++ b/assets/client/src/pages/LandingPage.js
@@ -2,20 +2,25 @@ import React, { useState, useEffect, useContext } from 'react'
 import { ChallengeTiles } from '../components/ChallengeTiles'
 import axios from 'axios'
 import { ApiUrlContext } from '../ApiUrlContext'
+import moment from "moment"
 
 export const LandingPage = () => {
   const [currentChallenges, setCurrentChallenges] = useState([])
   const [loadingState, setLoadingState] = useState(false)
+  const [isArchived] = useState(window.location.hash === "#/challenges/archived")
+  const [selectedYear, setSelectedYear] = useState(moment().year())
 
   const { apiUrl } = useContext(ApiUrlContext)
-  const challengesPath = window.location.hash === "#/challenges/archived" ? "/api/challenges?archived=true" : "/api/challenges"
+  const challengesPath = isArchived ? "/api/challenges?archived=true" : "/api/challenges"
 
   $(".usa-hero").show()
 
   useEffect(() => {
+    let yearFilter = isArchived ? `&filter[year]=${selectedYear}` : ""
+    
     setLoadingState(true)
     axios
-      .get(apiUrl + challengesPath)
+      .get(apiUrl + challengesPath + yearFilter)
       .then(res => {
         setCurrentChallenges(res.data)
         setLoadingState(false)
@@ -24,12 +29,16 @@ export const LandingPage = () => {
         setLoadingState(false)
         console.log({e})
       })
-  }, [])
+  }, [selectedYear])
+
+  const handleYearChange = (e) => {
+    setSelectedYear(e.target.value)
+  }
 
   return (
     <div>
       <div>
-        <ChallengeTiles data={currentChallenges} loading={loadingState}/>
+        <ChallengeTiles data={currentChallenges} loading={loadingState} isArchived={isArchived} selectedYear={selectedYear} handleYearChange={handleYearChange} />
       </div>
     </div>
   )

--- a/assets/client/src/routes/index.js
+++ b/assets/client/src/routes/index.js
@@ -8,6 +8,11 @@ export const IndexRoutes = [
     exact: true
   },
   {
+    component: App,
+    path: "/challenges/archived",
+    exact: true
+  },
+  {
     component: DetailsPage,
     path: "/challenge/:challengeId"
   }

--- a/assets/css/public/_challenge-tile.scss
+++ b/assets/css/public/_challenge-tile.scss
@@ -15,7 +15,6 @@ p {
 .cards {
   display: grid;
   // grid-template-columns: repeat(auto-fit, minmax(42.5rem, 1fr));
-  grid-gap: 2rem;
   margin: auto;
   padding: 20px;
 

--- a/assets/css/public/_challenge-tile.scss
+++ b/assets/css/public/_challenge-tile.scss
@@ -123,6 +123,10 @@ p {
 }
 
 .usa-tag {
+  &--archived {
+    background-color: #2C608A;
+  }
+
   &--coming-soon {
     background-color: #4d8055;
   }

--- a/assets/css/public/_challenge-tile.scss
+++ b/assets/css/public/_challenge-tile.scss
@@ -24,6 +24,8 @@ p {
   }
 
   &__section {
+    max-width: 1200px;
+    margin: auto;
     padding-top: 2rem;
 
     h2 {
@@ -32,6 +34,12 @@ p {
       text-align: center;
     }
 
+  }
+
+  &__year-filter {
+    margin: auto;
+    margin-bottom: 1rem;
+    text-align: center;
   }
 }
 

--- a/assets/js/app/_date_conversion.js
+++ b/assets/js/app/_date_conversion.js
@@ -9,7 +9,6 @@ $(".js-local-date").each(function() {
 })
 
 $(".js-local-datetime").each(function() {
-  console.log($(this))
   let timeZone = moment.tz.guess(true)
   let utc_time = $(this).text()
   let local_time = moment.tz(utc_time, timeZone).format("MM/DD/YY hh:mm A z")

--- a/assets/js/app/_session_timeout.js
+++ b/assets/js/app/_session_timeout.js
@@ -93,18 +93,18 @@ if ($("#session_timeout").length > 0) {
         return renewSession()
       }
 
-      // $.ajax({
-      //   url: "/api/session/logout",
-      //   type: "post",
-      //   processData: false,
-      //   contentType: false,
-      //   success: function(res) {
-      //     location.replace("/sign-in/new?inactive=true")
-      //   },
-      //   error: function(err) {
-      //     console.log("Something went wrong")
-      //   }
-      // })
+      $.ajax({
+        url: "/api/session/logout",
+        type: "post",
+        processData: false,
+        contentType: false,
+        success: function(res) {
+          location.replace("/sign-in/new?inactive=true")
+        },
+        error: function(err) {
+          console.log("Something went wrong")
+        }
+      })
     }
 
   }, 1000);

--- a/assets/js/app/_session_timeout.js
+++ b/assets/js/app/_session_timeout.js
@@ -93,18 +93,18 @@ if ($("#session_timeout").length > 0) {
         return renewSession()
       }
 
-      $.ajax({
-        url: "/api/session/logout",
-        type: "post",
-        processData: false,
-        contentType: false,
-        success: function(res) {
-          location.replace("/sign-in/new?inactive=true")
-        },
-        error: function(err) {
-          console.log("Something went wrong")
-        }
-      })
+      // $.ajax({
+      //   url: "/api/session/logout",
+      //   type: "post",
+      //   processData: false,
+      //   contentType: false,
+      //   success: function(res) {
+      //     location.replace("/sign-in/new?inactive=true")
+      //   },
+      //   error: function(err) {
+      //     console.log("Something went wrong")
+      //   }
+      // })
     }
 
   }, 1000);

--- a/config/config.exs
+++ b/config/config.exs
@@ -49,7 +49,8 @@ config :challenge_gov, ChallengeGov.Scheduler,
     {"0 5 * * *", {ChallengeGov.SecurityLogs, :check_expired_records, []}},
     {"* * * * *", {ChallengeGov.SecurityLogs, :check_for_timed_out_sessions, []}},
     {"0 0 * * *", {ChallengeGov.CertificationLogs, :check_for_expired_certifications, []}},
-    {"* * * * *", {ChallengeGov.Challenges, :check_for_auto_publish, []}}
+    {"* * * * *", {ChallengeGov.Challenges, :check_for_auto_publish, []}},
+    {"* * * * *", {ChallengeGov.Challenges, :set_sub_statuses, []}}
   ]
 
 # Import environment specific config. This must remain at the bottom

--- a/lib/challenge_gov/challenges.ex
+++ b/lib/challenge_gov/challenges.ex
@@ -1123,6 +1123,11 @@ defmodule ChallengeGov.Challenges do
     end)
   end
 
+  def filter_on_attribute({"year", value}, query) do
+    {value, _} = Integer.parse(value)
+    where(query, [c], fragment("date_part('year', ?) = ?", c.start_date, ^value))
+  end
+
   def filter_on_attribute({"agency_id", value}, query) do
     where(query, [c], c.agency_id == ^value)
   end

--- a/lib/challenge_gov/challenges.ex
+++ b/lib/challenge_gov/challenges.ex
@@ -33,6 +33,9 @@ defmodule ChallengeGov.Challenges do
   def statuses(), do: Challenge.statuses()
 
   @doc false
+  def sub_statuses(), do: Challenge.sub_statuses()
+
+  @doc false
   def status_label(status) do
     status_data = Enum.find(statuses(), fn s -> s.id == status end)
 
@@ -288,10 +291,24 @@ defmodule ChallengeGov.Challenges do
 
   def all_public(opts \\ []) do
     base_query()
-    |> where([c], c.status == "published")
+    |> where([c], c.status == "published" or c.sub_status == "open")
     |> where([c], c.end_date >= ^DateTime.utc_now())
     |> order_by([c], asc: c.end_date, asc: c.id)
     |> Filter.filter(opts[:filter], __MODULE__)
+    |> Repo.paginate(opts[:page], opts[:per])
+  end
+
+  @doc """
+  Gets all archived or sub_status archived challenges
+  """
+  def all_archived(opts \\ []) do
+    base_query()
+    |> where(
+      [c],
+      (c.status == "published" and c.sub_status == "archived") or c.status == "archived" or
+        c.archive_date <= ^DateTime.utc_now()
+    )
+    |> order_by([c], asc: c.end_date, asc: c.id)
     |> Repo.paginate(opts[:page], opts[:per])
   end
 
@@ -679,6 +696,8 @@ defmodule ChallengeGov.Challenges do
   def is_unpublished?(%{status: "unpublished"}), do: true
   def is_unpublished?(_user), do: false
 
+  def is_open?(%{sub_status: "open"}), do: true
+
   def is_open?(challenge = %{start_date: start_date, end_date: end_date})
       when not is_nil(start_date) and not is_nil(end_date) do
     now = DateTime.utc_now()
@@ -689,12 +708,21 @@ defmodule ChallengeGov.Challenges do
 
   def is_open?(_challenge), do: false
 
+  def is_closed?(%{sub_status: "closed"}), do: true
+
   def is_closed?(challenge = %{end_date: end_date}) when not is_nil(end_date) do
     now = DateTime.utc_now()
     is_published?(challenge) and DateTime.compare(now, end_date) === :gt
   end
 
   def is_closed?(_challenge), do: false
+
+  def is_archived_new?(%{sub_status: "archived"}), do: true
+
+  def is_archived_new?(challenge = %{archive_date: archive_date}) when not is_nil(archive_date) do
+    now = DateTime.utc_now()
+    is_published?(challenge) and DateTime.compare(now, archive_date) === :gt
+  end
 
   def is_archived_new?(challenge = %{phases: phases}) when length(phases) > 0 do
     now = DateTime.utc_now()
@@ -712,6 +740,39 @@ defmodule ChallengeGov.Challenges do
 
   def is_archived?(%{status: "archived"}), do: true
   def is_archived?(_user), do: false
+
+  def set_sub_statuses() do
+    Challenge
+    |> where([c], c.status == "published")
+    |> Repo.all()
+    |> Enum.reduce(Ecto.Multi.new(), fn challenge, multi ->
+      Ecto.Multi.update(multi, {:challenge, challenge.id}, set_sub_status(challenge))
+    end)
+    |> Repo.transaction()
+  end
+
+  def set_sub_status(challenge) do
+    cond do
+      is_archived_new?(challenge) ->
+        challenge
+        |> Ecto.Changeset.change()
+        |> Ecto.Changeset.put_change(:sub_status, "archived")
+
+      is_closed?(challenge) ->
+        challenge
+        |> Ecto.Changeset.change()
+        |> Ecto.Changeset.put_change(:sub_status, "closed")
+
+      is_open?(challenge) ->
+        challenge
+        |> Ecto.Changeset.change()
+        |> Ecto.Changeset.put_change(:sub_status, "open")
+
+      true ->
+        challenge
+        |> Ecto.Changeset.change()
+    end
+  end
 
   # BOOKMARK: Advanced status functions
   @doc """

--- a/lib/challenge_gov/challenges.ex
+++ b/lib/challenge_gov/challenges.ex
@@ -309,6 +309,7 @@ defmodule ChallengeGov.Challenges do
         c.archive_date <= ^DateTime.utc_now()
     )
     |> order_by([c], asc: c.end_date, asc: c.id)
+    |> Filter.filter(opts[:filter], __MODULE__)
     |> Repo.paginate(opts[:page], opts[:per])
   end
 
@@ -716,6 +717,8 @@ defmodule ChallengeGov.Challenges do
   end
 
   def is_closed?(_challenge), do: false
+
+  def is_archived_new?(%{status: "archived"}), do: true
 
   def is_archived_new?(%{sub_status: "archived"}), do: true
 

--- a/lib/challenge_gov/challenges.ex
+++ b/lib/challenge_gov/challenges.ex
@@ -305,10 +305,11 @@ defmodule ChallengeGov.Challenges do
     base_query()
     |> where(
       [c],
-      (c.status == "published" and c.sub_status == "archived") or c.status == "archived" or
-        c.archive_date <= ^DateTime.utc_now()
+      (c.status == "published" and (c.sub_status == "archived" or c.sub_status == "closed")) or
+        c.status == "archived" or
+        c.archive_date <= ^DateTime.utc_now() or c.end_date <= ^DateTime.utc_now()
     )
-    |> order_by([c], asc: c.end_date, asc: c.id)
+    |> order_by([c], desc: c.end_date, asc: c.id)
     |> Filter.filter(opts[:filter], __MODULE__)
     |> Repo.paginate(opts[:page], opts[:per])
   end

--- a/lib/challenge_gov/challenges/challenge.ex
+++ b/lib/challenge_gov/challenges/challenge.ex
@@ -56,6 +56,7 @@ defmodule ChallengeGov.Challenges.Challenge do
 
     # Fields
     field(:status, :string, default: "draft")
+    field(:sub_status, :string)
     field(:last_section, :string)
     field(:challenge_manager, :string)
     field(:challenge_manager_email, :string)
@@ -73,6 +74,7 @@ defmodule ChallengeGov.Challenges.Challenge do
     field(:fiscal_year, :string)
     field(:start_date, :utc_datetime)
     field(:end_date, :utc_datetime)
+    field(:archive_date, :utc_datetime)
     field(:multi_phase, :boolean)
     field(:number_of_phases, :string)
     field(:phase_descriptions, :string)
@@ -142,6 +144,17 @@ defmodule ChallengeGov.Challenges.Challenge do
   def status_ids() do
     Enum.map(@statuses, & &1.id)
   end
+
+  @doc """
+  Sub statuses that a published challenge can have
+  """
+  @sub_statuses [
+    "open",
+    "closed",
+    "archived"
+  ]
+
+  def sub_statuses(), do: @sub_statuses
 
   @challenge_types [
     "Software and apps",
@@ -251,6 +264,7 @@ defmodule ChallengeGov.Challenges.Challenge do
       :agency_id,
       :sub_agency_id,
       :status,
+      :sub_status,
       :challenge_manager,
       :challenge_manager_email,
       :poc_email,
@@ -312,6 +326,7 @@ defmodule ChallengeGov.Challenges.Challenge do
       :user_id,
       :agency_id,
       :status,
+      :sub_status,
       :challenge_manager,
       :challenge_manager_email,
       :poc_email,
@@ -714,6 +729,7 @@ defmodule ChallengeGov.Challenges.Challenge do
     struct
     |> set_start_date(phases)
     |> set_end_date(phases)
+    |> set_archive_date(phases)
   end
 
   defp maybe_set_start_end_dates(struct, _params), do: struct
@@ -749,6 +765,23 @@ defmodule ChallengeGov.Challenges.Challenge do
         |> Timex.parse("{ISO:Extended}")
 
       put_change(struct, :end_date, DateTime.truncate(end_date, :second))
+    else
+      struct
+    end
+  end
+
+  defp set_archive_date(struct, phases) do
+    if Enum.any?(phases, fn {_, phase} -> dates_exist?(phase) end) do
+      {_, end_phase} =
+        phases
+        |> Enum.max_by(fn {_, p} -> p["end_date"] end)
+
+      {:ok, end_date} =
+        end_phase
+        |> Map.fetch!("end_date")
+        |> Timex.parse("{ISO:Extended}")
+
+      put_change(struct, :archive_date, DateTime.truncate(end_date, :second))
     else
       struct
     end

--- a/lib/web/controllers/api/challenge_controller.ex
+++ b/lib/web/controllers/api/challenge_controller.ex
@@ -6,6 +6,18 @@ defmodule Web.Api.ChallengeController do
 
   plug Web.Plugs.FetchPage when action in [:index]
 
+  def index(conn, %{"archived" => "true"}) do
+    %{page: page, per: per} = conn.assigns
+
+    %{page: page, pagination: pagination} = Challenges.all_archived(page: page, per: per)
+
+    conn
+    |> assign(:challenges, page)
+    |> assign(:pagination, pagination)
+    |> assign(:base_url, Routes.api_challenge_url(conn, :index, archived: true))
+    |> render("index.json")
+  end
+
   def index(conn, _params) do
     %{page: page, per: per} = conn.assigns
 

--- a/lib/web/controllers/api/challenge_controller.ex
+++ b/lib/web/controllers/api/challenge_controller.ex
@@ -6,10 +6,12 @@ defmodule Web.Api.ChallengeController do
 
   plug Web.Plugs.FetchPage when action in [:index]
 
-  def index(conn, %{"archived" => "true"}) do
+  def index(conn, params = %{"archived" => "true"}) do
     %{page: page, per: per} = conn.assigns
+    filter = Map.get(params, "filter", %{})
 
-    %{page: page, pagination: pagination} = Challenges.all_archived(page: page, per: per)
+    %{page: page, pagination: pagination} =
+      Challenges.all_archived(filter: filter, page: page, per: per)
 
     conn
     |> assign(:challenges, page)

--- a/lib/web/views/api/challenge_view.ex
+++ b/lib/web/views/api/challenge_view.ex
@@ -25,6 +25,7 @@ defmodule Web.Api.ChallengeView do
       end_date: challenge.end_date,
       announcement_datetime: challenge.announcement_datetime,
       is_archived: Challenges.is_archived_new?(challenge),
+      is_closed: Challenges.is_closed?(challenge),
       phases:
         render_many(
           challenge.phases,
@@ -66,6 +67,7 @@ defmodule Web.Api.ChallengeView do
       how_to_enter: HtmlSanitizeEx.basic_html(challenge.how_to_enter),
       id: challenge.id,
       is_archived: Challenges.is_archived_new?(challenge),
+      is_closed: Challenges.is_closed?(challenge),
       judging_criteria: HtmlSanitizeEx.basic_html(challenge.judging_criteria),
       legal_authority: challenge.legal_authority,
       logo: ChallengeView.logo_url(challenge),

--- a/lib/web/views/api/challenge_view.ex
+++ b/lib/web/views/api/challenge_view.ex
@@ -24,6 +24,7 @@ defmodule Web.Api.ChallengeView do
       start_date: challenge.start_date,
       end_date: challenge.end_date,
       announcement_datetime: challenge.announcement_datetime,
+      is_archived: Challenges.is_archived_new?(challenge),
       phases:
         render_many(
           challenge.phases,
@@ -64,6 +65,7 @@ defmodule Web.Api.ChallengeView do
       faq: HtmlSanitizeEx.basic_html(challenge.faq),
       how_to_enter: HtmlSanitizeEx.basic_html(challenge.how_to_enter),
       id: challenge.id,
+      is_archived: Challenges.is_archived_new?(challenge),
       judging_criteria: HtmlSanitizeEx.basic_html(challenge.judging_criteria),
       legal_authority: challenge.legal_authority,
       logo: ChallengeView.logo_url(challenge),

--- a/priv/repo/migrations/20200907002801_add_sub_status_to_challenges.exs
+++ b/priv/repo/migrations/20200907002801_add_sub_status_to_challenges.exs
@@ -1,0 +1,9 @@
+defmodule ChallengeGov.Repo.Migrations.AddSubStatusToChallenges do
+  use Ecto.Migration
+
+  def change do
+    alter table(:challenges) do
+      add :sub_status, :string
+    end
+  end
+end

--- a/priv/repo/migrations/20200910005419_add_archive_date_to_challenges.exs
+++ b/priv/repo/migrations/20200910005419_add_archive_date_to_challenges.exs
@@ -1,0 +1,9 @@
+defmodule ChallengeGov.Repo.Migrations.AddArchiveDateToChallenges do
+  use Ecto.Migration
+
+  def change do
+    alter table(:challenges) do
+      add :archive_date, :utc_datetime
+    end
+  end
+end

--- a/test/challenge_gov/challenges/challenge_test.exs
+++ b/test/challenge_gov/challenges/challenge_test.exs
@@ -86,4 +86,43 @@ defmodule ChallengeGov.ChallengeTest do
       assert challenge.announcement_datetime === DateTime.truncate(DateTime.utc_now(), :second)
     end
   end
+
+  describe "set published sub statuses" do
+    test "successfully" do
+      user = AccountHelpers.create_user()
+      challenge = ChallengeHelpers.create_single_phase_challenge(user, %{user_id: user.id})
+
+      multi_phase_challenge =
+        ChallengeHelpers.create_multi_phase_challenge(user, %{user_id: user.id})
+
+      open_multi_phase_challenge =
+        ChallengeHelpers.create_open_multi_phase_challenge(user, %{user_id: user.id})
+
+      closed_multi_phase_challenge =
+        ChallengeHelpers.create_closed_multi_phase_challenge(user, %{user_id: user.id})
+
+      archived_multi_phase_challenge =
+        ChallengeHelpers.create_archived_multi_phase_challenge(user, %{user_id: user.id})
+
+      assert challenge.sub_status === nil
+      assert multi_phase_challenge.sub_status === nil
+      assert open_multi_phase_challenge.sub_status === nil
+      assert closed_multi_phase_challenge.sub_status === nil
+      assert archived_multi_phase_challenge.sub_status === nil
+
+      Challenges.set_sub_statuses()
+
+      {:ok, challenge} = Challenges.get(challenge.id)
+      {:ok, multi_phase_challenge} = Challenges.get(multi_phase_challenge.id)
+      {:ok, open_multi_phase_challenge} = Challenges.get(open_multi_phase_challenge.id)
+      {:ok, closed_multi_phase_challenge} = Challenges.get(closed_multi_phase_challenge.id)
+      {:ok, archived_multi_phase_challenge} = Challenges.get(archived_multi_phase_challenge.id)
+
+      assert challenge.sub_status === "open"
+      assert multi_phase_challenge.sub_status === nil
+      assert open_multi_phase_challenge.sub_status === "open"
+      assert closed_multi_phase_challenge.sub_status === "closed"
+      assert archived_multi_phase_challenge.sub_status === "archived"
+    end
+  end
 end

--- a/test/support/test_helpers/challenge_helpers.ex
+++ b/test/support/test_helpers/challenge_helpers.ex
@@ -123,4 +123,118 @@ defmodule ChallengeGov.TestHelpers.ChallengeHelpers do
 
     challenge
   end
+
+  def create_open_multi_phase_challenge(user, attributes \\ %{}) do
+    challenge = create_challenge(attributes, user)
+
+    {:ok, challenge} =
+      Challenges.update(
+        challenge,
+        %{
+          "action" => "next",
+          "challenge" => %{
+            "section" => "details",
+            "challenge_title" => challenge.title,
+            "upload_logo" => "false",
+            "is_multi_phase" => "true",
+            "phases" => %{
+              "0" => %{
+                "title" => "Test",
+                "start_date" => TestHelpers.iso_timestamp(),
+                "end_date" => TestHelpers.iso_timestamp(hours: 1),
+                "open_to_submissions" => "true"
+              },
+              "1" => %{
+                "title" => "Test 1",
+                "start_date" => TestHelpers.iso_timestamp(hours: 2),
+                "end_date" => TestHelpers.iso_timestamp(hours: 3),
+                "open_to_submissions" => "true"
+              },
+              "2" => %{
+                "title" => "Test 2",
+                "start_date" => TestHelpers.iso_timestamp(hours: 4),
+                "end_date" => TestHelpers.iso_timestamp(hours: 5),
+                "open_to_submissions" => "false"
+              }
+            }
+          }
+        },
+        user,
+        ""
+      )
+
+    challenge
+  end
+
+  def create_closed_multi_phase_challenge(user, attributes \\ %{}) do
+    challenge = create_challenge(attributes, user)
+
+    {:ok, challenge} =
+      Challenges.update(
+        challenge,
+        %{
+          "action" => "next",
+          "challenge" => %{
+            "section" => "details",
+            "challenge_title" => challenge.title,
+            "upload_logo" => "false",
+            "is_multi_phase" => "true",
+            "phases" => %{
+              "0" => %{
+                "title" => "Test",
+                "start_date" => TestHelpers.iso_timestamp(hours: -2),
+                "end_date" => TestHelpers.iso_timestamp(hours: -1),
+                "open_to_submissions" => "true"
+              },
+              "1" => %{
+                "title" => "Test 2",
+                "start_date" => TestHelpers.iso_timestamp(),
+                "end_date" => TestHelpers.iso_timestamp(hours: 1),
+                "open_to_submissions" => "false"
+              }
+            }
+          }
+        },
+        user,
+        ""
+      )
+
+    challenge
+  end
+
+  def create_archived_multi_phase_challenge(user, attributes \\ %{}) do
+    challenge = create_challenge(attributes, user)
+
+    {:ok, challenge} =
+      Challenges.update(
+        challenge,
+        %{
+          "action" => "next",
+          "challenge" => %{
+            "section" => "details",
+            "challenge_title" => challenge.title,
+            "upload_logo" => "false",
+            "is_multi_phase" => "true",
+            "phases" => %{
+              "0" => %{
+                "title" => "Test",
+                "start_date" => TestHelpers.iso_timestamp(hours: -4),
+                "end_date" => TestHelpers.iso_timestamp(hours: -3),
+                "open_to_submissions" => "true"
+              },
+              "1" => %{
+                "title" => "Test 2",
+                "start_date" => TestHelpers.iso_timestamp(hours: -2),
+                "end_date" => TestHelpers.iso_timestamp(hours: -1),
+                "open_to_submissions" => "false"
+              }
+            }
+          }
+        },
+        user,
+        ""
+      )
+
+    challenge
+  end
 end

--- a/test/web/controllers/api/challenge_controller_test.exs
+++ b/test/web/controllers/api/challenge_controller_test.exs
@@ -70,6 +70,38 @@ defmodule Web.Api.ChallengeControllerTest do
       assert length(json_response(conn, 200)["collection"]) === 2
     end
 
+    test "success: filter by year", %{conn: conn} do
+      user = AccountHelpers.create_user()
+
+      now = Timex.now()
+
+      ChallengeHelpers.create_challenge(%{
+        user_id: user.id,
+        start_date: Timex.set(now, month: 1, year: 2018),
+        end_date: Timex.set(now, month: 2, year: 2018),
+        archive_date: Timex.set(now, month: 3, year: 2018)
+      })
+
+      ChallengeHelpers.create_challenge(%{
+        user_id: user.id,
+        start_date: Timex.set(now, month: 1, year: 2019),
+        end_date: Timex.set(now, month: 2, year: 2019),
+        archive_date: Timex.set(now, month: 3, year: 2019)
+      })
+
+      ChallengeHelpers.create_challenge(%{
+        user_id: user.id,
+        start_date: Timex.shift(now, hours: 1),
+        end_date: Timex.shift(now, hours: 2),
+        archive_date: Timex.shift(now, hours: 2)
+      })
+
+      conn =
+        get(conn, Routes.api_challenge_path(conn, :index, archived: true, filter: %{year: 2019}))
+
+      assert length(json_response(conn, 200)["collection"]) === 1
+    end
+
     test "no results", %{conn: conn} do
       conn = get(conn, Routes.api_challenge_path(conn, :index), archived: true)
       assert length(json_response(conn, 200)["collection"]) === 0

--- a/test/web/controllers/api/challenge_controller_test.exs
+++ b/test/web/controllers/api/challenge_controller_test.exs
@@ -48,6 +48,32 @@ defmodule Web.Api.ChallengeControllerTest do
     end
   end
 
+  describe "retrieving JSON list of archived challenges" do
+    test "successfully", %{conn: conn} do
+      user = AccountHelpers.create_user()
+
+      ChallengeHelpers.create_single_phase_challenge(user, %{
+        user_id: user.id
+      })
+
+      ChallengeHelpers.create_multi_phase_challenge(user, %{user_id: user.id})
+
+      ChallengeHelpers.create_open_multi_phase_challenge(user, %{user_id: user.id})
+
+      ChallengeHelpers.create_closed_multi_phase_challenge(user, %{user_id: user.id})
+
+      ChallengeHelpers.create_archived_multi_phase_challenge(user, %{user_id: user.id})
+
+      conn = get(conn, Routes.api_challenge_path(conn, :index, archived: true))
+      assert length(json_response(conn, 200)["collection"]) === 1
+    end
+
+    test "no results", %{conn: conn} do
+      conn = get(conn, Routes.api_challenge_path(conn, :index), archived: true)
+      assert length(json_response(conn, 200)["collection"]) === 0
+    end
+  end
+
   describe "retrieving JSON details of a challenge" do
     test "successfully with published challenge", %{conn: conn} do
       user = AccountHelpers.create_user()

--- a/test/web/controllers/api/challenge_controller_test.exs
+++ b/test/web/controllers/api/challenge_controller_test.exs
@@ -67,7 +67,7 @@ defmodule Web.Api.ChallengeControllerTest do
       ChallengeHelpers.create_archived_multi_phase_challenge(user, %{user_id: user.id})
 
       conn = get(conn, Routes.api_challenge_path(conn, :index, archived: true))
-      assert length(json_response(conn, 200)["collection"]) === 1
+      assert length(json_response(conn, 200)["collection"]) === 2
     end
 
     test "no results", %{conn: conn} do
@@ -222,7 +222,8 @@ defmodule Web.Api.ChallengeControllerTest do
       "open_until" => nil,
       "announcement" => nil,
       "announcement_datetime" => nil,
-      "is_archived" => Challenges.is_archived_new?(challenge)
+      "is_archived" => Challenges.is_archived_new?(challenge),
+      "is_closed" => Challenges.is_closed?(challenge)
     }
   end
 end

--- a/test/web/controllers/api/challenge_controller_test.exs
+++ b/test/web/controllers/api/challenge_controller_test.exs
@@ -1,6 +1,8 @@
 defmodule Web.Api.ChallengeControllerTest do
   use Web.ConnCase
 
+  alias ChallengeGov.Challenges
+
   alias ChallengeGov.TestHelpers.AccountHelpers
   alias ChallengeGov.TestHelpers.AgencyHelpers
   alias ChallengeGov.TestHelpers.ChallengeHelpers
@@ -219,7 +221,8 @@ defmodule Web.Api.ChallengeControllerTest do
       "phases" => [],
       "open_until" => nil,
       "announcement" => nil,
-      "announcement_datetime" => nil
+      "announcement_datetime" => nil,
+      "is_archived" => Challenges.is_archived_new?(challenge)
     }
   end
 end


### PR DESCRIPTION
- Adds api endpoint and year filtering for archived challenges
- Update challenge tile react app to use new archive endpoint when hash route matches `challenges/archived`
- Added year filter select box to react app
- Added archived tags to challenge tiles that are archived
- Added banners for closed/archived challenges when viewing the challenge detail page
- A few refactors to the challenge tiles and landing page components to work better when embedded in federalist