### PR TITLE
Fix duplicates from challenge importer

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,25 @@ The ChallengeGov runs each pull request (and every commit on the `master` branch
 
 Passing CI on master deploys to the dev environment via Cloud Foundry as part of the Drone build.
 
+## Importing Data
+
+Run importers in order of Open, Closed, ClosedImported. Afterward set the challlenges_seq_id to the max challenge-id.
+
+Commands to run:
+
+```
+$ iex -S mix run
+> Mix.Tasks.OpenChallengeImporter.run("")
+> Mix.Tasks.ClosedChallengeImporter.run("")
+> Mix.Tasks.ClosedImportedChallengeImporter.run("")
+```
+
+In psql after imports:
+
+```
+SELECT setval('challenges_id_seq', max(id)) FROM challenges;
+```
+
 ## Learn more about Phoenix
 
   * Official website: http://www.phoenixframework.org/

--- a/lib/challenge_gov/challenges/challenge.ex
+++ b/lib/challenge_gov/challenges/challenge.ex
@@ -326,6 +326,7 @@ defmodule ChallengeGov.Challenges.Challenge do
   def import_changeset(struct, params) do
     struct
     |> cast(params, [
+      :id,
       :user_id,
       :agency_id,
       :status,
@@ -366,6 +367,7 @@ defmodule ChallengeGov.Challenges.Challenge do
       :is_multi_phase,
       :imported
     ])
+    |> unique_constraint(:id, name: :challenges_pkey)
     |> cast_assoc(:non_federal_partners, with: &NonFederalPartner.draft_changeset/2)
     |> cast_assoc(:events)
     |> cast_assoc(:phases, with: &Phase.draft_changeset/2)

--- a/lib/mix/tasks/closed_challenge_importer.ex
+++ b/lib/mix/tasks/closed_challenge_importer.ex
@@ -32,6 +32,7 @@ defmodule Mix.Tasks.ClosedChallengeImporter do
   def create_challenge(json, import_user_id) do
     result =
       Challenges.import_create(%{
+        "id" => json["challenge-id"],
         "imported" => true,
         "user_id" => import_user_id,
         "status" => "published",

--- a/lib/mix/tasks/closed_imported_challenge_importer.ex
+++ b/lib/mix/tasks/closed_imported_challenge_importer.ex
@@ -32,6 +32,7 @@ defmodule Mix.Tasks.ClosedImportedChallengeImporter do
   def create_challenge(json, import_user_id) do
     result =
       Challenges.import_create(%{
+        "id" => json["challenge-id"],
         "imported" => true,
         "user_id" => import_user_id,
         "title" => json["challenge-title"],

--- a/lib/mix/tasks/open_challenge_importer.ex
+++ b/lib/mix/tasks/open_challenge_importer.ex
@@ -32,6 +32,7 @@ defmodule Mix.Tasks.OpenChallengeImporter do
   def create_challenge(json, import_user_id) do
     result =
       Challenges.import_create(%{
+        "id" => json["challenge-id"],
         "imported" => true,
         "user_id" => import_user_id,
         "title" => json["challenge-title"],


### PR DESCRIPTION
Fixes duplicated in challenge importer by using the challenge-id as the id in challenges database table. Run importers in order of `Open`, `Closed`, `ClosedImported`. Afterward set the challlenges_seq_id to the max challenge-id

Commands to run:
`iex -S mix run`
In mix: 
`Mix.Tasks.OpenChallengeImporter.run("")`
`Mix.Tasks.ClosedChallengeImporter.run("")`
`Mix.Tasks.ClosedImportedChallengeImporter.run("")`
In psql after imports:
`SELECT setval('challenges_id_seq', max(id)) FROM challenges;`