### PR TITLE
Initial solution management for challenges/phases

### DIFF
--- a/lib/challenge_gov/challenges.ex
+++ b/lib/challenge_gov/challenges.ex
@@ -12,6 +12,7 @@ defmodule ChallengeGov.Challenges do
   alias ChallengeGov.Challenges.ResourceBanner
   alias ChallengeGov.Emails
   alias ChallengeGov.Mailer
+  alias ChallengeGov.Phases
   alias ChallengeGov.Repo
   alias ChallengeGov.SavedChallenges
   alias ChallengeGov.SecurityLogs
@@ -745,6 +746,22 @@ defmodule ChallengeGov.Challenges do
   def find_end_date(challenge) do
     challenge.end_date
   end
+
+  def current_phase(%{phases: phases}) when length(phases) > 0 do
+    phases
+    |> Enum.find(fn phase ->
+      Phases.is_current?(phase)
+    end)
+    |> case do
+      nil ->
+        {:error, :no_current_phase}
+
+      phase ->
+        {:ok, phase}
+    end
+  end
+
+  def current_phase(_challenge), do: {:error, :no_current_phase}
 
   @doc """
   Create a new status event when the status changes

--- a/lib/challenge_gov/challenges/phase.ex
+++ b/lib/challenge_gov/challenges/phase.ex
@@ -8,11 +8,13 @@ defmodule ChallengeGov.Challenges.Phase do
   import Ecto.Changeset
 
   alias ChallengeGov.Challenges.Challenge
+  alias ChallengeGov.Solutions.Solution
 
   @type t :: %__MODULE__{}
 
   schema "phases" do
     belongs_to(:challenge, Challenge)
+    has_many(:solutions, Solution)
 
     field(:uuid, Ecto.UUID, autogenerate: true)
     field(:title, :string)

--- a/lib/challenge_gov/phases.ex
+++ b/lib/challenge_gov/phases.ex
@@ -1,0 +1,33 @@
+defmodule ChallengeGov.Phases do
+  alias ChallengeGov.Repo
+  alias ChallengeGov.Challenges.Phase
+  alias Stein.Filter
+
+  import Ecto.Query
+
+  @behaviour Stein.Filter
+
+  def all(opts \\ []) do
+    Phase
+    |> Filter.filter(opts[:filter], __MODULE__)
+    |> Repo.all()
+  end
+
+  def get(id) do
+    Phase
+    |> Repo.get(id)
+    |> case do
+      nil ->
+        {:error, :not_found}
+
+      phase ->
+        {:ok, phase}
+    end
+  end
+
+  def filter_on_attribute({"challenge_id", value}, query) do
+    where(query, [c], c.challenge_id == ^value)
+  end
+
+  def filter_on_attribute(_, query), do: query
+end

--- a/lib/challenge_gov/phases.ex
+++ b/lib/challenge_gov/phases.ex
@@ -1,4 +1,8 @@
 defmodule ChallengeGov.Phases do
+  @moduledoc """
+  Context for Phases
+  """
+
   alias ChallengeGov.Repo
   alias ChallengeGov.Challenges.Phase
   alias Stein.Filter

--- a/lib/challenge_gov/phases.ex
+++ b/lib/challenge_gov/phases.ex
@@ -13,12 +13,15 @@ defmodule ChallengeGov.Phases do
 
   def all(opts \\ []) do
     Phase
+    |> preload([:solutions])
+    |> order_by(asc: :start_date)
     |> Filter.filter(opts[:filter], __MODULE__)
     |> Repo.all()
   end
 
   def get(id) do
     Phase
+    |> preload([:solutions])
     |> Repo.get(id)
     |> case do
       nil ->
@@ -35,6 +38,20 @@ defmodule ChallengeGov.Phases do
   end
 
   def is_current?(_phase), do: false
+
+  def is_past?(%{end_date: end_date}) do
+    now = DateTime.utc_now()
+    now > end_date
+  end
+
+  def is_past?(_phase), do: false
+
+  def is_future?(%{start_date: start_date}) do
+    now = DateTime.utc_now()
+    now < start_date
+  end
+
+  def is_future?(_phase), do: false
 
   def filter_on_attribute({"challenge_id", value}, query) do
     where(query, [c], c.challenge_id == ^value)

--- a/lib/challenge_gov/phases.ex
+++ b/lib/challenge_gov/phases.ex
@@ -13,7 +13,7 @@ defmodule ChallengeGov.Phases do
 
   def all(opts \\ []) do
     Phase
-    |> preload([:solutions])
+    |> base_query
     |> order_by(asc: :start_date)
     |> Filter.filter(opts[:filter], __MODULE__)
     |> Repo.all()
@@ -21,7 +21,7 @@ defmodule ChallengeGov.Phases do
 
   def get(id) do
     Phase
-    |> preload([:solutions])
+    |> base_query
     |> Repo.get(id)
     |> case do
       nil ->
@@ -30,6 +30,11 @@ defmodule ChallengeGov.Phases do
       phase ->
         {:ok, phase}
     end
+  end
+
+  defp base_query(query) do
+    query
+    |> preload([:challenge, :solutions])
   end
 
   def is_current?(%{start_date: start_date, end_date: end_date}) do

--- a/lib/challenge_gov/phases.ex
+++ b/lib/challenge_gov/phases.ex
@@ -29,6 +29,13 @@ defmodule ChallengeGov.Phases do
     end
   end
 
+  def is_current?(%{start_date: start_date, end_date: end_date}) do
+    now = DateTime.utc_now()
+    now >= start_date && now <= end_date
+  end
+
+  def is_current?(_phase), do: false
+
   def filter_on_attribute({"challenge_id", value}, query) do
     where(query, [c], c.challenge_id == ^value)
   end

--- a/lib/challenge_gov/solutions.ex
+++ b/lib/challenge_gov/solutions.ex
@@ -53,9 +53,9 @@ defmodule ChallengeGov.Solutions do
     Repo.preload(solution, [:submitter, :documents, challenge: [:agency]])
   end
 
-  def create_draft(params, user, challenge) do
+  def create_draft(params, user, challenge, phase) do
     params = attach_default_multi_params(params)
-    changeset = Solution.draft_changeset(%Solution{}, params, user, challenge)
+    changeset = Solution.draft_changeset(%Solution{}, params, user, challenge, phase)
 
     Ecto.Multi.new()
     |> Ecto.Multi.insert(:solution, changeset)
@@ -75,9 +75,9 @@ defmodule ChallengeGov.Solutions do
     end
   end
 
-  def create_review(params, user, challenge) do
+  def create_review(params, user, challenge, phase) do
     params = attach_default_multi_params(params)
-    changeset = Solution.review_changeset(%Solution{}, params, user, challenge)
+    changeset = Solution.review_changeset(%Solution{}, params, user, challenge, phase)
 
     Ecto.Multi.new()
     |> Ecto.Multi.insert(:solution, changeset)

--- a/lib/challenge_gov/solutions.ex
+++ b/lib/challenge_gov/solutions.ex
@@ -21,6 +21,7 @@ defmodule ChallengeGov.Solutions do
     |> base_preload
     |> where([s], is_nil(s.deleted_at))
     |> Filter.filter(opts[:filter], __MODULE__)
+    |> order_on_attribute(opts[:sort])
     |> Repo.paginate(opts[:page], opts[:per])
   end
 
@@ -245,6 +246,23 @@ defmodule ChallengeGov.Solutions do
 
   defp preserve_document_ids_on_error(changeset, _params), do: changeset
 
+  def update_judging_status(solution, judging_status) do
+    case judging_status do
+      "select" ->
+        solution
+        |> Solution.select_for_judging_changeset()
+        |> Repo.update()
+
+      "unselect" ->
+        solution
+        |> Solution.unselect_for_judging_changeset()
+        |> Repo.update()
+
+      _ ->
+        {:error, :invalid_judging_status}
+    end
+  end
+
   @doc false
   def statuses(), do: Solution.statuses()
 
@@ -322,4 +340,27 @@ defmodule ChallengeGov.Solutions do
     value = "%" <> value <> "%"
     where(query, [s], ilike(s.status, ^value))
   end
+
+  def order_on_attribute(query, sort_columns)
+      when is_map(sort_columns) and map_size(sort_columns) > 0 do
+    columns_to_sort =
+      Enum.reduce(sort_columns, [], fn {column, direction}, acc ->
+        column = String.to_atom(column)
+
+        case direction do
+          "asc" ->
+            acc ++ [asc_nulls_last: column]
+
+          "desc" ->
+            acc ++ [desc_nulls_last: column]
+
+          _ ->
+            []
+        end
+      end)
+
+    order_by(query, [c], ^columns_to_sort)
+  end
+
+  def order_on_attribute(query, _), do: order_by(query, [c], desc_nulls_last: :id)
 end

--- a/lib/challenge_gov/solutions.ex
+++ b/lib/challenge_gov/solutions.ex
@@ -294,6 +294,10 @@ defmodule ChallengeGov.Solutions do
     where(query, [c], c.challenge_id == ^value)
   end
 
+  def filter_on_attribute({"phase_id", value}, query) do
+    where(query, [c], c.phase_id == ^value)
+  end
+
   def filter_on_attribute({"title", value}, query) do
     value = "%" <> value <> "%"
     where(query, [s], ilike(s.title, ^value))

--- a/lib/challenge_gov/solutions/solution.ex
+++ b/lib/challenge_gov/solutions/solution.ex
@@ -9,6 +9,7 @@ defmodule ChallengeGov.Solutions.Solution do
 
   alias ChallengeGov.Accounts.User
   alias ChallengeGov.Challenges.Challenge
+  alias ChallengeGov.Challenges.Phase
   alias ChallengeGov.Solutions.Document
 
   @type t :: %__MODULE__{}
@@ -28,6 +29,7 @@ defmodule ChallengeGov.Solutions.Solution do
     # Associations
     belongs_to(:submitter, User)
     belongs_to(:challenge, Challenge)
+    belongs_to(:phase, Phase)
     has_many(:documents, Document)
     field(:document_ids, :map, virtual: true)
 
@@ -53,26 +55,30 @@ defmodule ChallengeGov.Solutions.Solution do
     ])
   end
 
-  def draft_changeset(struct, params, user, challenge) do
+  def draft_changeset(struct, params, user, challenge, phase) do
     struct
     |> changeset(params)
     |> put_change(:submitter_id, user.id)
     |> put_change(:challenge_id, challenge.id)
+    |> put_change(:phase_id, phase.id)
     |> put_change(:status, "draft")
     |> foreign_key_constraint(:submitter)
     |> foreign_key_constraint(:challenge)
+    |> foreign_key_constraint(:phase)
     |> validate_inclusion(:status, status_ids())
     |> validate_length(:brief_description, max: 500)
   end
 
-  def review_changeset(struct, params, user, challenge) do
+  def review_changeset(struct, params, user, challenge, phase) do
     struct
     |> changeset(params)
     |> put_change(:submitter_id, user.id)
     |> put_change(:challenge_id, challenge.id)
+    |> put_change(:phase_id, phase.id)
     |> put_change(:status, "draft")
     |> foreign_key_constraint(:submitter)
     |> foreign_key_constraint(:challenge)
+    |> foreign_key_constraint(:phase)
     |> validate_inclusion(:status, status_ids())
     |> validate_required([
       :title,
@@ -88,6 +94,7 @@ defmodule ChallengeGov.Solutions.Solution do
     |> put_change(:status, "draft")
     |> foreign_key_constraint(:submitter)
     |> foreign_key_constraint(:challenge)
+    |> foreign_key_constraint(:phase)
     |> validate_inclusion(:status, status_ids())
     |> validate_length(:brief_description, max: 500)
   end
@@ -98,6 +105,7 @@ defmodule ChallengeGov.Solutions.Solution do
     |> put_change(:status, "draft")
     |> foreign_key_constraint(:submitter)
     |> foreign_key_constraint(:challenge)
+    |> foreign_key_constraint(:phase)
     |> validate_inclusion(:status, status_ids())
     |> validate_required([
       :title,

--- a/lib/challenge_gov/solutions/solution.ex
+++ b/lib/challenge_gov/solutions/solution.ex
@@ -19,11 +19,20 @@ defmodule ChallengeGov.Solutions.Solution do
     %{id: "submitted", label: "Submitted"}
   ]
 
+  @judging_statuses [
+    "not_selected",
+    "selected",
+    "qualified",
+    "winner"
+  ]
+
   def statuses(), do: @statuses
 
   def status_ids() do
     Enum.map(@statuses, & &1.id)
   end
+
+  def judging_statuses, do: @judging_statuses
 
   schema "solutions" do
     # Associations
@@ -39,6 +48,7 @@ defmodule ChallengeGov.Solutions.Solution do
     field(:description, :string)
     field(:external_url, :string)
     field(:status, :string)
+    field(:judging_status, :string, default: "not_selected")
 
     # Meta Timestamps
     field(:deleted_at, :utc_datetime)
@@ -121,6 +131,22 @@ defmodule ChallengeGov.Solutions.Solution do
     |> put_change(:status, "submitted")
     |> validate_required_fields
     |> validate_inclusion(:status, status_ids())
+  end
+
+  def select_for_judging_changeset(struct) do
+    struct
+    |> change()
+    |> put_change(:judging_status, "selected")
+    |> validate_required_fields
+    |> validate_inclusion(:status, judging_statuses())
+  end
+
+  def unselect_for_judging_changeset(struct) do
+    struct
+    |> change()
+    |> put_change(:judging_status, "not_selected")
+    |> validate_required_fields
+    |> validate_inclusion(:status, judging_statuses())
   end
 
   def delete_changeset(struct) do

--- a/lib/web/controllers/phase_controller.ex
+++ b/lib/web/controllers/phase_controller.ex
@@ -14,6 +14,7 @@ defmodule Web.PhaseController do
          phases <- Phases.all(filter: %{"challenge_id" => challenge.id}) do
       conn
       |> assign(:user, user)
+      |> assign(:challenge, challenge)
       |> assign(:phases, phases)
       |> render("index.html")
     else
@@ -41,10 +42,11 @@ defmodule Web.PhaseController do
     %{current_user: user} = conn.assigns
 
     with {:ok, challenge} <- Challenges.get(challenge_id),
-         {:ok, _challenge} <- Challenges.allowed_to_edit(user, challenge),
+         {:ok, challenge} <- Challenges.allowed_to_edit(user, challenge),
          {:ok, phase} <- Phases.get(id) do
       conn
       |> assign(:user, user)
+      |> assign(:challenge, challenge)
       |> assign(:phase, phase)
       |> render("show.html")
     else

--- a/lib/web/controllers/phase_controller.ex
+++ b/lib/web/controllers/phase_controller.ex
@@ -1,0 +1,70 @@
+defmodule Web.PhaseController do
+  use Web, :controller
+
+  alias ChallengeGov.Challenges
+  alias ChallengeGov.Phases
+
+  plug Web.Plugs.EnsureRole, [:super_admin, :admin, :challenge_owner]
+
+  def index(conn, %{"challenge_id" => challenge_id}) do
+    %{current_user: user} = conn.assigns
+
+    with {:ok, challenge} <- Challenges.get(challenge_id),
+         {:ok, challenge} <- Challenges.allowed_to_edit(user, challenge),
+         phases <- Phases.all(filter: %{"challenge_id" => challenge.id}) do
+      conn
+      |> assign(:user, user)
+      |> assign(:phases, phases)
+      |> render("index.html")
+    else
+      {:error, :not_permitted} ->
+        conn
+        |> assign(:user, user)
+        |> put_flash(:error, "You are not allowed to view this challenge's phases")
+        |> redirect(to: Routes.challenge_path(conn, :index))
+
+      {:error, :not_found} ->
+        conn
+        |> assign(:user, user)
+        |> put_flash(:error, "Challenge not found")
+        |> redirect(to: Routes.challenge_path(conn, :index))
+
+      _ ->
+        conn
+        |> assign(:user, user)
+        |> put_flash(:error, "Something went wrong")
+        |> redirect(to: Routes.challenge_path(conn, :index))
+    end
+  end
+
+  def show(conn, %{"challenge_id" => challenge_id, "id" => id}) do
+    %{current_user: user} = conn.assigns
+
+    with {:ok, challenge} <- Challenges.get(challenge_id),
+         {:ok, _challenge} <- Challenges.allowed_to_edit(user, challenge),
+         {:ok, phase} <- Phases.get(id) do
+      conn
+      |> assign(:user, user)
+      |> assign(:phase, phase)
+      |> render("show.html")
+    else
+      {:error, :not_permitted} ->
+        conn
+        |> assign(:user, user)
+        |> put_flash(:error, "You are not allowed to view this phase")
+        |> redirect(to: Routes.challenge_path(conn, :index))
+
+      {:error, :not_found} ->
+        conn
+        |> assign(:user, user)
+        |> put_flash(:error, "Phase not found")
+        |> redirect(to: Routes.challenge_path(conn, :index))
+
+      _ ->
+        conn
+        |> assign(:user, user)
+        |> put_flash(:error, "Something went wrong")
+        |> redirect(to: Routes.challenge_path(conn, :index))
+    end
+  end
+end

--- a/lib/web/controllers/phase_controller.ex
+++ b/lib/web/controllers/phase_controller.ex
@@ -51,8 +51,14 @@ defmodule Web.PhaseController do
     with {:ok, challenge} <- Challenges.get(challenge_id),
          {:ok, challenge} <- Challenges.allowed_to_edit(user, challenge),
          {:ok, phase} <- Phases.get(id) do
+      solutions_filter =
+        Map.merge(filter, %{
+          "status" => "submitted",
+          "phase_id" => phase.id
+        })
+
       %{page: solutions, pagination: pagination} =
-        Solutions.all(filter: %{"phase_id" => phase.id}, page: page, per: per)
+        Solutions.all(filter: solutions_filter, page: page, per: per, sort: sort)
 
       conn
       |> assign(:user, user)

--- a/lib/web/router.ex
+++ b/lib/web/router.ex
@@ -89,6 +89,10 @@ defmodule Web.Router do
 
       resources("/bulletin", BulletinController, only: [:new, :create])
 
+      resources("/phases", PhaseController, only: [:index, :show]) do
+        resources("/solutions", SolutionController, only: [:index, :show, :new, :create])
+      end
+
       resources("/solutions", SolutionController, only: [:index, :new, :create])
 
       resources("/save_challenge", SavedChallengeController, only: [:new, :create])

--- a/lib/web/router.ex
+++ b/lib/web/router.ex
@@ -94,6 +94,7 @@ defmodule Web.Router do
       end
 
       resources("/solutions", SolutionController, only: [:index, :new, :create])
+      put("/solutions/:id/:judging_status", SolutionController, :update_judging_status)
 
       resources("/save_challenge", SavedChallengeController, only: [:new, :create])
     end

--- a/lib/web/templates/challenge/show/_other_actions.html.eex
+++ b/lib/web/templates/challenge/show/_other_actions.html.eex
@@ -2,6 +2,7 @@
   <div class="card-body">
     <h4>Other actions</h4>
     <div class="btn-toolbar">
+      <%= challenge_solutions_link(@conn, @challenge, @user, label: "View submissions", class: "btn btn-primary") %>
       <%= if Accounts.has_admin_access?(@user) or !(Challenges.is_archived?(@challenge) or Challenges.is_archived_new?(@challenge)) do %>
         <%= link "Preview", to: Routes.public_preview_path(@conn, :index, @challenge.uuid), target: "_blank", class: "btn btn-info" %>
         <%= link "Print", to: Routes.public_preview_path(@conn, :index, @challenge.uuid, print: true), target: "_blank", class: "btn btn-info" %>

--- a/lib/web/templates/challenge/table/_content.html.eex
+++ b/lib/web/templates/challenge/table/_content.html.eex
@@ -27,6 +27,7 @@
             </button>
             <div class="dropdown-menu" aria-labelledby="btnGroupDrop1">
               <a class="btn btn-link" href="#">Media</a>
+              <%= challenge_solutions_link(@conn, challenge, @user, class: "btn btn-link") %>
               <%= link "Preview", to: Routes.public_preview_path(@conn, :index, challenge.uuid), target: "_blank", class: "btn btn-link" %>
               <%= link "Print", to: Routes.public_preview_path(@conn, :index, challenge.uuid, print: true), target: "_blank", class: "btn btn-link" %>
               <%= link "Download JSON", to: Routes.export_path(@conn, :export_challenge, challenge.id, "json"), target: "_blank", class: "btn btn-link" %>

--- a/lib/web/templates/challenge/table/_content.html.eex
+++ b/lib/web/templates/challenge/table/_content.html.eex
@@ -26,16 +26,23 @@
               More options
             </button>
             <div class="dropdown-menu" aria-labelledby="btnGroupDrop1">
-              <a class="btn btn-link" href="#">Media</a>
-              <%= challenge_solutions_link(@conn, challenge, @user, class: "btn btn-link") %>
-              <%= link "Preview", to: Routes.public_preview_path(@conn, :index, challenge.uuid), target: "_blank", class: "btn btn-link" %>
-              <%= link "Print", to: Routes.public_preview_path(@conn, :index, challenge.uuid, print: true), target: "_blank", class: "btn btn-link" %>
-              <%= link "Download JSON", to: Routes.export_path(@conn, :export_challenge, challenge.id, "json"), target: "_blank", class: "btn btn-link" %>
-              <%= link "Download CSV", to: Routes.export_path(@conn, :export_challenge, challenge.id, "csv"), target: "_blank", class: "btn btn-link" %>
+              <a class="btn btn-link btn-xs" href="#">Media</a>
+              <hr/>
+              <%= challenge_solutions_link(@conn, challenge, @user, class: "btn btn-link btn-xs") %>
+              <hr/>
+              <%= link "Preview", to: Routes.public_preview_path(@conn, :index, challenge.uuid), target: "_blank", class: "btn btn-link btn-xs" %>
+              <hr/>
+              <%= link "Print", to: Routes.public_preview_path(@conn, :index, challenge.uuid, print: true), target: "_blank", class: "btn btn-link btn-xs" %>
+              <hr/>
+              <%= link "Download JSON", to: Routes.export_path(@conn, :export_challenge, challenge.id, "json"), target: "_blank", class: "btn btn-link btn-xs" %>
+              <hr/>
+              <%= link "Download CSV", to: Routes.export_path(@conn, :export_challenge, challenge.id, "csv"), target: "_blank", class: "btn btn-link btn-xs" %>
+              <hr/>
               <%= if not is_nil(challenge.gov_delivery_topic) do %>
-                <%= link("Send Bulletin", to: Routes.challenge_bulletin_path(@conn, :new, challenge.id), class: "btn btn-link") %>
+                <%= link("Send Bulletin", to: Routes.challenge_bulletin_path(@conn, :new, challenge.id), class: "btn btn-link btn-xs") %>
+                <hr/>
               <% end %>
-              <%= challenge_delete_link(@conn, challenge, @user, label: "Delete", class: "btn btn-link text-danger") %>
+              <%= challenge_delete_link(@conn, challenge, @user, label: "Delete", class: "btn btn-link text-danger btn-xs") %>
             </div>
           </div>
         </div>

--- a/lib/web/templates/layout/app.html.eex
+++ b/lib/web/templates/layout/app.html.eex
@@ -144,7 +144,7 @@
 
       <aside class="control-sidebar control-sidebar-light">
         <div class="p-3">
-          <%= if action_name(@conn) == :index and @view_module != Web.DashboardView and @view_module != Web.AccessView and @view_module != Web.SiteContentView do %>
+          <%= if load_filter_panel(@conn, @view_module) do %>
             <%= render @view_module, "_filter.html", conn: @conn, user: @user, filter: @filter, sort: @sort %>
           <% end%>
         </div>

--- a/lib/web/templates/phase/_card.html.eex
+++ b/lib/web/templates/phase/_card.html.eex
@@ -1,0 +1,14 @@
+<div class="card">
+  <div class="card-body">
+    <h3><%= "Phase #{@index + 1}: #{@phase.title}" %></h3>
+    <div class="mb-2">
+      <div><span>Start date: </span><span class="js-local-datetime"><%= @phase.start_date %></span></div>
+      <div><span>End date: </span><span class="js-local-datetime"><%= @phase.end_date %></span></div>
+    </div>
+    <div class="mb-2">Status: <%= status(@phase) %></div>
+    <div class="mb-3">Submission total: <%= length(@phase.solutions) %></div>
+    <div>
+      <%= link("Manage submissions", to: Routes.challenge_phase_path(@conn, :show, @challenge.id, @phase.id), class: "btn btn-primary") %>
+    </div>
+  </div>
+</div>

--- a/lib/web/templates/phase/index.html.eex
+++ b/lib/web/templates/phase/index.html.eex
@@ -1,11 +1,7 @@
 <div class="content-header">
   <div class="container-fluid">
-    <div class="row mb-2">
-      <div class="col-sm-6">
-        <h2>View submissions for <%= @challenge.title %></h2>
-      </div>
-
-      <div class="col-sm-6">
+    <div class="row">
+      <div class="col">
         <ol class="breadcrumb float-sm-right">
           <li class="breadcrumb-item">
             <%= link(to: Routes.dashboard_path(@conn, :index)) do %>
@@ -16,6 +12,12 @@
           <li class="breadcrumb-item"><%= link(@challenge.title, to: Routes.challenge_path(@conn, :show, @challenge.id)) %></li>
           <li class="breadcrumb-item active">Phases</li>
         </ol>
+      </div>
+    </div>
+
+    <div class="row mb-2">
+      <div class="col-sm-6">
+        <h2>View submissions for <%= @challenge.title %></h2>
       </div>
     </div>
   </div>

--- a/lib/web/templates/phase/index.html.eex
+++ b/lib/web/templates/phase/index.html.eex
@@ -1,8 +1,38 @@
-<h1>Phase Index</h1>
-<ul>
-  <%= Enum.map(@phases, fn phase -> %>
-    <li>
-      <%= link("Phase #{phase.id}", to: Routes.challenge_phase_path(@conn, :show, @challenge.id, phase.id)) %>
-    </li>
-  <% end) %>
-</ul>
+<div class="content-header">
+  <div class="container-fluid">
+    <div class="row mb-2">
+      <div class="col-sm-6">
+        <h2>View submissions for <%= @challenge.title %></h2>
+      </div>
+
+      <div class="col-sm-6">
+        <ol class="breadcrumb float-sm-right">
+          <li class="breadcrumb-item">
+            <%= link(to: Routes.dashboard_path(@conn, :index)) do %>
+              <i class="fa fa-dashboard"></i> Home
+            <% end %>
+          </li>
+          <li class="breadcrumb-item"><%= link("Challenges", to: Routes.challenge_path(@conn, :index)) %></li>
+          <li class="breadcrumb-item"><%= link(@challenge.title, to: Routes.challenge_path(@conn, :show, @challenge.id)) %></li>
+          <li class="breadcrumb-item active">Phases</li>
+        </ol>
+      </div>
+    </div>
+  </div>
+</div>
+
+<section class="container-fluid px-5">
+  <%= if !Enum.empty?(@phases) do %>
+    <%= Enum.map(Enum.with_index(@phases), fn {phase, index} -> %>
+      <%= if rem(index, 3) === 0 do %>
+        <div class="row">
+      <% end %>
+      <div class="col-md-4 p-5">
+        <%= render "_card.html", conn: @conn, challenge: @challenge, phase: phase, index: index %>
+      </div>
+      <%= if rem(index, 3) === 2 or length(@phases) - 1 === index do %>
+        </div>
+      <% end %>
+    <% end) %>
+  <% end %>
+</section>

--- a/lib/web/templates/phase/index.html.eex
+++ b/lib/web/templates/phase/index.html.eex
@@ -1,0 +1,8 @@
+<h1>Phase Index</h1>
+<ul>
+  <%= Enum.map(@phases, fn phase -> %>
+    <li>
+      <%= link("Phase #{phase.id}", to: Routes.challenge_phase_path(@conn, :show, @challenge.id, phase.id)) %>
+    </li>
+  <% end) %>
+</ul>

--- a/lib/web/templates/phase/show.html.eex
+++ b/lib/web/templates/phase/show.html.eex
@@ -1,0 +1,7 @@
+<h1>Phase Show</h1>
+<ul>
+  <li><%= @phase.title %></li>
+  <li><%= @phase.start_date %></li>
+  <li><%= @phase.end_date %></li>
+  <li><%= @phase.open_to_submissions %></li>
+</ul>

--- a/lib/web/templates/phase/show.html.eex
+++ b/lib/web/templates/phase/show.html.eex
@@ -1,7 +1,35 @@
-<h1>Phase Show</h1>
-<ul>
-  <li><%= @phase.title %></li>
-  <li><%= @phase.start_date %></li>
-  <li><%= @phase.end_date %></li>
-  <li><%= @phase.open_to_submissions %></li>
-</ul>
+<div class="content-header">
+  <div class="container-fluid">
+    <div class="row">
+      <div class="col">
+        <ol class="breadcrumb float-sm-right">
+          <li class="breadcrumb-item">
+            <%= link(to: Routes.dashboard_path(@conn, :index)) do %>
+              <i class="fa fa-dashboard"></i> Home
+            <% end %>
+          </li>
+          <li class="breadcrumb-item"><%= link("Challenges", to: Routes.challenge_path(@conn, :index)) %></li>
+          <li class="breadcrumb-item"><%= link(@challenge.title, to: Routes.challenge_path(@conn, :show, @challenge.id)) %></li>
+          <%= if length(@challenge.phases) > 1 do %>
+            <li class="breadcrumb-item"><%= link("Phases", to: Routes.challenge_phase_path(@conn, :index, @challenge.id)) %></li>
+            <li class="breadcrumb-item active"><%= @phase.title %></li>
+          <% else %>
+            <li class="breadcrumb-item active"><%= @phase.title %></li>
+          <% end %>
+        </ol>
+      </div>
+    </div>
+
+    <div class="row">
+      <div class="col">
+        <%= if length(@challenge.phases) > 1 do %>
+          <h2>Solutions for Phase: <span class="font-italic"><%= @phase.title %></span> of Challenge: <span class="font-italic"><%= @challenge.title %></span></h2>
+        <% else %>
+          <h2>Solutions for <span class="font-italic"><%= @challenge.title %></span></h2>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>
+
+<%= render Web.PhaseView, "solution_table/_table.html", conn: @conn, user: @user, challenge: @challenge, phase: @phase, solutions: @solutions, pagination: @pagination, sort: @sort, filter: @filter %>

--- a/lib/web/templates/phase/solution_table/_content.html.eex
+++ b/lib/web/templates/phase/solution_table/_content.html.eex
@@ -6,7 +6,7 @@
       <td class="js-local-datetime"><%= solution.updated_at %></td>
       <td>last_messaged_placeholder</td>
       <td>topic_placeholder</td>
-      <td>selected_for_judging</td>
+      <td><%= render_select_for_judging_button(@conn, @challenge, solution) %></td>
       <td>other_actions</td>
     </tr>
   <% end %>

--- a/lib/web/templates/phase/solution_table/_content.html.eex
+++ b/lib/web/templates/phase/solution_table/_content.html.eex
@@ -1,0 +1,13 @@
+<tbody>
+  <%= Enum.map @solutions, fn (solution) -> %>
+    <tr>
+      <td><%= solution.id %></td>
+      <td><%= solution.title %></td>
+      <td class="js-local-datetime"><%= solution.updated_at %></td>
+      <td>last_messaged_placeholder</td>
+      <td>topic_placeholder</td>
+      <td>selected_for_judging</td>
+      <td>other_actions</td>
+    </tr>
+  <% end %>
+</tbody>

--- a/lib/web/templates/phase/solution_table/_content.html.eex
+++ b/lib/web/templates/phase/solution_table/_content.html.eex
@@ -7,7 +7,31 @@
       <td>last_messaged_placeholder</td>
       <td>topic_placeholder</td>
       <td><%= render_select_for_judging_button(@conn, @challenge, solution) %></td>
-      <td>other_actions</td>
+      <td>
+        <div class="btn-group btn-group-sm" role="group" aria-label="Button group with nested dropdown">
+          <div class="btn-group btn-group-sm ml-2" role="group">
+            <button id="btnGroupDrop1" type="button" class="btn btn-secondary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+              More options
+            </button>
+            <div class="dropdown-menu" aria-labelledby="btnGroupDrop1">
+              <%= 
+                link("Unselect",
+                  to:
+                    Routes.challenge_solution_path(
+                      @conn,
+                      :update_judging_status,
+                      @challenge.id,
+                      solution.id,
+                      "unselect"
+                    ),
+                  method: :put,
+                  class: "btn btn-link btn-xs"
+                )
+              %>
+            </div>
+          </div>
+        </div>
+      </td>
     </tr>
   <% end %>
 </tbody>

--- a/lib/web/templates/phase/solution_table/_header.html.eex
+++ b/lib/web/templates/phase/solution_table/_header.html.eex
@@ -3,9 +3,9 @@
     <%= sortable_header(@conn, @sort, @filter, "id", "ID", @phase) %>
     <%= sortable_header(@conn, @sort, @filter, "title", "Name", @phase) %>
     <%= sortable_header(@conn, @sort, @filter, "updated_at", "Last Updated", @phase) %>
-    <%= sortable_header(@conn, @sort, @filter, "last_messaged", "Last Messaged", @phase) %>
+    <%= sortable_header(@conn, @sort, @filter, "id", "Last Messaged", @phase) %>
     <th>Topic</th>
-    <%= sortable_header(@conn, @sort, @filter, "selected_for_judging", "Selected for Judging", @phase) %>
+    <%= sortable_header(@conn, @sort, @filter, "judging_status", "Selected for Judging", @phase) %>
     <th>Other Actions</th>
   </tr>
 </thead>

--- a/lib/web/templates/phase/solution_table/_header.html.eex
+++ b/lib/web/templates/phase/solution_table/_header.html.eex
@@ -1,0 +1,11 @@
+<thead>
+  <tr>
+    <%= sortable_header(@conn, @sort, @filter, "id", "ID", @phase) %>
+    <%= sortable_header(@conn, @sort, @filter, "title", "Name", @phase) %>
+    <%= sortable_header(@conn, @sort, @filter, "updated_at", "Last Updated", @phase) %>
+    <%= sortable_header(@conn, @sort, @filter, "last_messaged", "Last Messaged", @phase) %>
+    <th>Topic</th>
+    <%= sortable_header(@conn, @sort, @filter, "selected_for_judging", "Selected for Judging", @phase) %>
+    <th>Other Actions</th>
+  </tr>
+</thead>

--- a/lib/web/templates/phase/solution_table/_table.html.eex
+++ b/lib/web/templates/phase/solution_table/_table.html.eex
@@ -1,0 +1,18 @@
+<section class="content">
+  <div class="container-fluid">
+    <div class="row">
+      <div class="col-md-12">
+        <div class="card">
+          <div class="table-responsive">
+            <table class="table table-striped">
+              <%= render Web.PhaseView, "solution_table/_header.html", conn: @conn, user: @user, filter: @filter, sort: @sort, phase: @phase %>
+              <%= render Web.PhaseView, "solution_table/_content.html", conn: @conn, user: @user, solutions: @solutions %>
+            </table>
+          </div>
+
+          <%= Web.SharedView.pagination(path: Routes.challenge_phase_path(@conn, :show, @challenge.id, @phase.id, filter: @filter, sort: @sort), pagination: @pagination) %>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>

--- a/lib/web/templates/phase/solution_table/_table.html.eex
+++ b/lib/web/templates/phase/solution_table/_table.html.eex
@@ -6,7 +6,7 @@
           <div class="table-responsive">
             <table class="table table-striped">
               <%= render Web.PhaseView, "solution_table/_header.html", conn: @conn, user: @user, filter: @filter, sort: @sort, phase: @phase %>
-              <%= render Web.PhaseView, "solution_table/_content.html", conn: @conn, user: @user, solutions: @solutions %>
+              <%= render Web.PhaseView, "solution_table/_content.html", conn: @conn, user: @user, challenge: @challenge, solutions: @solutions %>
             </table>
           </div>
 

--- a/lib/web/views/challenge_view.ex
+++ b/lib/web/views/challenge_view.ex
@@ -104,6 +104,32 @@ defmodule Web.ChallengeView do
 
   def published_sub_status_display(_challenge, _attached), do: ""
 
+  def challenge_solutions_link(conn, challenge, user, opts \\ []) do
+    if (user.role == "challenge_owner" or
+          Accounts.has_admin_access?(user)) and length(challenge.phases) > 0 do
+      link_location =
+        if length(challenge.phases) > 1,
+          do: Routes.challenge_phase_path(conn, :index, challenge.id),
+          else:
+            Routes.challenge_phase_path(
+              conn,
+              :show,
+              challenge.id,
+              Enum.at(challenge.phases, 0).id
+            )
+
+      link(
+        opts[:label] || "View submissions",
+        Keyword.merge(
+          [
+            to: link_location
+          ],
+          opts
+        )
+      )
+    end
+  end
+
   def challenge_edit_link(conn, challenge, opts \\ []) do
     route =
       if challenge.status == "draft" do

--- a/lib/web/views/layout_view.ex
+++ b/lib/web/views/layout_view.ex
@@ -70,6 +70,14 @@ defmodule Web.LayoutView do
         ""
     end
   end
+
+  def load_filter_panel(conn, view_module) do
+    action_name(conn) == :index and
+      view_module != Web.DashboardView and
+      view_module != Web.AccessView and
+      view_module != Web.SiteContentView and
+      view_module != Web.PhaseView
+  end
 end
 
 defmodule Web.PageTitle do

--- a/lib/web/views/phase_view.ex
+++ b/lib/web/views/phase_view.ex
@@ -1,0 +1,3 @@
+defmodule Web.PhaseView do
+  use Web, :view
+end

--- a/lib/web/views/phase_view.ex
+++ b/lib/web/views/phase_view.ex
@@ -19,4 +19,37 @@ defmodule Web.PhaseView do
         ]
     end
   end
+
+  # TODO: Refactor to be more generic
+  # Example: Take a path with existing query params and append sort after and no longer need to pass filter
+  def sortable_header(conn, sort, filter, column, label, phase) do
+    {sort_icon, sort_values} =
+      case Map.get(sort, column) do
+        "asc" ->
+          {"fa-sort-up", Map.put(%{}, column, :desc)}
+
+        "desc" ->
+          {"fa-sort-down", %{}}
+
+        _ ->
+          {"fa-sort", Map.put(%{}, column, :asc)}
+      end
+
+    content_tag :th do
+      link(
+        to:
+          Routes.challenge_phase_path(conn, :show, phase.challenge.id, phase.id,
+            filter: filter,
+            sort: sort_values
+          )
+      ) do
+        content_tag :div do
+          [
+            content_tag(:span, label),
+            content_tag(:i, "", class: "fa " <> sort_icon)
+          ]
+        end
+      end
+    end
+  end
 end

--- a/lib/web/views/phase_view.ex
+++ b/lib/web/views/phase_view.ex
@@ -1,3 +1,22 @@
 defmodule Web.PhaseView do
   use Web, :view
+
+  alias ChallengeGov.Phases
+  alias Web.SharedView
+
+  def status(phase) do
+    cond do
+      Phases.is_past?(phase) ->
+        content_tag(:span, "Closed to submissions")
+
+      Phases.is_current?(phase) ->
+        content_tag(:span, "Open to submissions")
+
+      Phases.is_future?(phase) ->
+        [
+          content_tag(:span, "Opens on "),
+          SharedView.local_datetime_tag(phase.start_date, "span")
+        ]
+    end
+  end
 end

--- a/lib/web/views/phase_view.ex
+++ b/lib/web/views/phase_view.ex
@@ -52,4 +52,30 @@ defmodule Web.PhaseView do
       end
     end
   end
+
+  def render_select_for_judging_button(conn, challenge, solution) do
+    {text, status_to_set} =
+      case solution.judging_status do
+        "selected" ->
+          {"Selected", "unselect"}
+
+        "not_selected" ->
+          {"Select", "select"}
+
+        _ ->
+          {"Error", "error"}
+      end
+
+    link(text,
+      to:
+        Routes.challenge_solution_path(
+          conn,
+          :update_judging_status,
+          challenge.id,
+          solution.id,
+          status_to_set
+        ),
+      method: :put
+    )
+  end
 end

--- a/lib/web/views/phase_view.ex
+++ b/lib/web/views/phase_view.ex
@@ -57,10 +57,16 @@ defmodule Web.PhaseView do
     {text, status_to_set} =
       case solution.judging_status do
         "selected" ->
-          {"Selected", "unselect"}
+          {
+            content_tag(:div, "Selected", class: "btn btn-primary btn-xs"),
+            "unselect"
+          }
 
         "not_selected" ->
-          {"Select", "select"}
+          {
+            content_tag(:div, "Add", class: "btn btn-secondary btn-xs"),
+            "select"
+          }
 
         _ ->
           {"Error", "error"}

--- a/lib/web/views/shared_view.ex
+++ b/lib/web/views/shared_view.ex
@@ -94,6 +94,10 @@ defmodule Web.SharedView do
     |> readable_datetime
   end
 
+  def local_datetime_tag(datetime, tag_type \\ "div") do
+    content_tag(tag_type, datetime, class: "js-local-datetime")
+  end
+
   def string_to_link(string, opts \\ []) do
     link(string, Keyword.merge([to: string], opts))
   end

--- a/priv/repo/migrations/20201106190632_add_solutions_to_phases.exs
+++ b/priv/repo/migrations/20201106190632_add_solutions_to_phases.exs
@@ -1,0 +1,9 @@
+defmodule ChallengeGov.Repo.Migrations.AddSolutionsToPhases do
+  use Ecto.Migration
+
+  def change do
+    alter table(:solutions) do
+      add(:phase_id, references(:phases), null: false)
+    end
+  end
+end

--- a/priv/repo/migrations/20201109170549_add_judging_status_to_solutions.exs
+++ b/priv/repo/migrations/20201109170549_add_judging_status_to_solutions.exs
@@ -1,0 +1,9 @@
+defmodule ChallengeGov.Repo.Migrations.AddJudgingStatusToSolutions do
+  use Ecto.Migration
+
+  def change do
+    alter table(:solutions) do
+      add(:judging_status, :string, default: "not_selected")
+    end
+  end
+end

--- a/test/challenge_gov/challenges/challenge_test.exs
+++ b/test/challenge_gov/challenges/challenge_test.exs
@@ -75,6 +75,49 @@ defmodule ChallengeGov.ChallengeTest do
     end
   end
 
+  describe "find current phase" do
+    test "success: single phase challenge" do
+      user = AccountHelpers.create_user()
+      challenge = ChallengeHelpers.create_single_phase_challenge(user, %{user_id: user.id})
+
+      {:ok, phase} = Challenges.current_phase(challenge)
+
+      assert phase
+    end
+
+    test "success: multi phase challenge" do
+      user = AccountHelpers.create_user()
+      challenge = ChallengeHelpers.create_open_multi_phase_challenge(user, %{user_id: user.id})
+
+      {:ok, phase} = Challenges.current_phase(challenge)
+
+      assert phase
+    end
+
+    test "failure: no current phase in single phase" do
+      user = AccountHelpers.create_user()
+      challenge = ChallengeHelpers.create_closed_single_phase_challenge(user, %{user_id: user.id})
+
+      assert {:error, :no_current_phase} === Challenges.current_phase(challenge)
+    end
+
+    test "failure: no current phase in multi phase" do
+      user = AccountHelpers.create_user()
+
+      challenge =
+        ChallengeHelpers.create_archived_multi_phase_challenge(user, %{user_id: user.id})
+
+      assert {:error, :no_current_phase} === Challenges.current_phase(challenge)
+    end
+
+    test "failure: no phases" do
+      user = AccountHelpers.create_user()
+      challenge = ChallengeHelpers.create_challenge(%{user_id: user.id}, user)
+
+      assert {:error, :no_current_phase} === Challenges.current_phase(challenge)
+    end
+  end
+
   describe "create announcement" do
     test "successfully" do
       user = AccountHelpers.create_user()

--- a/test/challenge_gov/phases_test.exs
+++ b/test/challenge_gov/phases_test.exs
@@ -1,0 +1,41 @@
+defmodule ChallengeGov.PhasesTest do
+  use ChallengeGov.DataCase
+
+  alias ChallengeGov.Phases
+  alias ChallengeGov.TestHelpers.AccountHelpers
+  alias ChallengeGov.TestHelpers.ChallengeHelpers
+
+  describe "retrieving phases for a challenge" do
+    test "success: single phase" do
+      user = AccountHelpers.create_user()
+      challenge = ChallengeHelpers.create_single_phase_challenge(user, %{user_id: user.id})
+      _challenge_2 = ChallengeHelpers.create_single_phase_challenge(user, %{user_id: user.id})
+
+      assert length(Phases.all(filter: %{"challenge_id" => challenge.id})) === 1
+    end
+
+    test "success: multiple phases" do
+      user = AccountHelpers.create_user()
+      challenge = ChallengeHelpers.create_multi_phase_challenge(user, %{user_id: user.id})
+      _challenge_2 = ChallengeHelpers.create_multi_phase_challenge(user, %{user_id: user.id})
+
+      assert length(Phases.all(filter: %{"challenge_id" => challenge.id})) === 3
+    end
+  end
+
+  describe "retrieving a phase in a challenge from an ID" do
+    test "success" do
+      user = AccountHelpers.create_user()
+      challenge = ChallengeHelpers.create_single_phase_challenge(user, %{user_id: user.id})
+
+      phase_id = Enum.at(challenge.phases, 0).id
+      {:ok, phase} = Phases.get(phase_id)
+
+      assert phase.challenge_id === challenge.id
+    end
+
+    test "failure: not found" do
+      assert Phases.get(-1) === {:error, :not_found}
+    end
+  end
+end

--- a/test/challenge_gov/solution_documents_test.exs
+++ b/test/challenge_gov/solution_documents_test.exs
@@ -27,7 +27,7 @@ defmodule ChallengeGov.SolutionDocumentsTest do
   describe "attaching to a solution" do
     test "successfully" do
       user = AccountHelpers.create_user()
-      challenge = ChallengeHelpers.create_challenge(%{user_id: user.id})
+      challenge = ChallengeHelpers.create_single_phase_challenge(user, %{user_id: user.id})
       solution = SolutionHelpers.create_submitted_solution(%{}, user, challenge)
 
       document =
@@ -41,7 +41,7 @@ defmodule ChallengeGov.SolutionDocumentsTest do
 
     test "already assigned" do
       user = AccountHelpers.create_user()
-      challenge = ChallengeHelpers.create_challenge(%{user_id: user.id})
+      challenge = ChallengeHelpers.create_single_phase_challenge(user, %{user_id: user.id})
       solution_1 = SolutionHelpers.create_submitted_solution(%{}, user, challenge)
       solution_2 = SolutionHelpers.create_submitted_solution(%{}, user, challenge)
 
@@ -55,7 +55,7 @@ defmodule ChallengeGov.SolutionDocumentsTest do
 
     test "attempting to assign another user's solution" do
       user = AccountHelpers.create_user()
-      challenge = ChallengeHelpers.create_challenge(%{user_id: user.id})
+      challenge = ChallengeHelpers.create_single_phase_challenge(user, %{user_id: user.id})
 
       user_1 = AccountHelpers.create_user(%{email: "user1@example.com"})
       solution_1 = SolutionHelpers.create_submitted_solution(%{}, user_1, challenge)

--- a/test/challenge_gov/solutions_test.exs
+++ b/test/challenge_gov/solutions_test.exs
@@ -12,7 +12,8 @@ defmodule ChallengeGov.SolutionsTest do
   describe "creating a solution" do
     test "saving as draft with no data" do
       user = AccountHelpers.create_user()
-      challenge = ChallengeHelpers.create_challenge(%{user_id: user.id})
+      challenge = ChallengeHelpers.create_single_phase_challenge(user, %{user_id: user.id})
+      phase = Enum.at(challenge.phases, 0)
 
       {:ok, solution} =
         Solutions.create_draft(
@@ -21,7 +22,8 @@ defmodule ChallengeGov.SolutionsTest do
             "solution" => %{}
           },
           user,
-          challenge
+          challenge,
+          phase
         )
 
       assert solution.submitter_id === user.id
@@ -32,7 +34,8 @@ defmodule ChallengeGov.SolutionsTest do
 
     test "saving as draft with data" do
       user = AccountHelpers.create_user()
-      challenge = ChallengeHelpers.create_challenge(%{user_id: user.id})
+      challenge = ChallengeHelpers.create_single_phase_challenge(user, %{user_id: user.id})
+      phase = Enum.at(challenge.phases, 0)
 
       {:ok, solution} =
         Solutions.create_draft(
@@ -43,7 +46,8 @@ defmodule ChallengeGov.SolutionsTest do
             "external_url" => "www.example.com"
           },
           user,
-          challenge
+          challenge,
+          phase
         )
 
       assert solution.submitter_id === user.id
@@ -57,7 +61,8 @@ defmodule ChallengeGov.SolutionsTest do
 
     test "submitting with no data" do
       user = AccountHelpers.create_user()
-      challenge = ChallengeHelpers.create_challenge(%{user_id: user.id})
+      challenge = ChallengeHelpers.create_single_phase_challenge(user, %{user_id: user.id})
+      phase = Enum.at(challenge.phases, 0)
 
       {:error, changeset} =
         Solutions.create_review(
@@ -66,7 +71,8 @@ defmodule ChallengeGov.SolutionsTest do
             "solution" => %{}
           },
           user,
-          challenge
+          challenge,
+          phase
         )
 
       assert changeset.errors[:title]
@@ -76,7 +82,8 @@ defmodule ChallengeGov.SolutionsTest do
 
     test "submitting with data" do
       user = AccountHelpers.create_user()
-      challenge = ChallengeHelpers.create_challenge(%{user_id: user.id})
+      challenge = ChallengeHelpers.create_single_phase_challenge(user, %{user_id: user.id})
+      phase = Enum.at(challenge.phases, 0)
 
       {:ok, solution} =
         Solutions.create_review(
@@ -87,7 +94,8 @@ defmodule ChallengeGov.SolutionsTest do
             "external_url" => "www.example.com"
           },
           user,
-          challenge
+          challenge,
+          phase
         )
 
       {:ok, solution} = Solutions.submit(solution)
@@ -105,9 +113,10 @@ defmodule ChallengeGov.SolutionsTest do
   describe "updating a solution" do
     test "update draft removing data" do
       user = AccountHelpers.create_user()
-      challenge = ChallengeHelpers.create_challenge(%{user_id: user.id})
+      challenge = ChallengeHelpers.create_single_phase_challenge(user, %{user_id: user.id})
+      phase = Enum.at(challenge.phases, 0)
 
-      solution = SolutionHelpers.create_draft_solution(%{}, user, challenge)
+      solution = SolutionHelpers.create_draft_solution(%{}, user, challenge, phase)
 
       {:ok, updated_solution} =
         Solutions.update_draft(
@@ -126,7 +135,7 @@ defmodule ChallengeGov.SolutionsTest do
 
     test "update draft changing data" do
       user = AccountHelpers.create_user()
-      challenge = ChallengeHelpers.create_challenge(%{user_id: user.id})
+      challenge = ChallengeHelpers.create_single_phase_challenge(user, %{user_id: user.id})
 
       solution = SolutionHelpers.create_draft_solution(%{}, user, challenge)
 
@@ -149,7 +158,7 @@ defmodule ChallengeGov.SolutionsTest do
 
     test "update draft to submitted no other changes" do
       user = AccountHelpers.create_user()
-      challenge = ChallengeHelpers.create_challenge(%{user_id: user.id})
+      challenge = ChallengeHelpers.create_single_phase_challenge(user, %{user_id: user.id})
 
       solution = SolutionHelpers.create_draft_solution(%{}, user, challenge)
 
@@ -166,7 +175,7 @@ defmodule ChallengeGov.SolutionsTest do
 
     test "update draft to submitted with invalid change" do
       user = AccountHelpers.create_user()
-      challenge = ChallengeHelpers.create_challenge(%{user_id: user.id})
+      challenge = ChallengeHelpers.create_single_phase_challenge(user, %{user_id: user.id})
 
       solution = SolutionHelpers.create_draft_solution(%{}, user, challenge)
 
@@ -184,7 +193,7 @@ defmodule ChallengeGov.SolutionsTest do
       user_2 = AccountHelpers.create_user(%{email: "user_2@example.com"})
 
       challenge =
-        ChallengeHelpers.create_challenge(%{
+        ChallengeHelpers.create_single_phase_challenge(user, %{
           user_id: user.id,
           challenge_owners: [user.id, user_2.id]
         })
@@ -217,7 +226,7 @@ defmodule ChallengeGov.SolutionsTest do
 
     test "update submitted with invalid value" do
       user = AccountHelpers.create_user()
-      challenge = ChallengeHelpers.create_challenge(%{user_id: user.id})
+      challenge = ChallengeHelpers.create_single_phase_challenge(user, %{user_id: user.id})
 
       solution = SolutionHelpers.create_submitted_solution(%{}, user, challenge)
 
@@ -234,7 +243,7 @@ defmodule ChallengeGov.SolutionsTest do
   describe "deleting a solution" do
     test "successfully" do
       user = AccountHelpers.create_user()
-      challenge = ChallengeHelpers.create_challenge(%{user_id: user.id})
+      challenge = ChallengeHelpers.create_single_phase_challenge(user, %{user_id: user.id})
 
       solution = SolutionHelpers.create_submitted_solution(%{}, user, challenge)
 
@@ -247,7 +256,7 @@ defmodule ChallengeGov.SolutionsTest do
   describe "fetching multiple solutions" do
     test "all solutions" do
       user = AccountHelpers.create_user()
-      challenge = ChallengeHelpers.create_challenge(%{user_id: user.id})
+      challenge = ChallengeHelpers.create_single_phase_challenge(user, %{user_id: user.id})
 
       SolutionHelpers.create_submitted_solution(%{}, user, challenge)
 
@@ -266,7 +275,7 @@ defmodule ChallengeGov.SolutionsTest do
 
     test "all solutions paginated" do
       user = AccountHelpers.create_user()
-      challenge = ChallengeHelpers.create_challenge(%{user_id: user.id})
+      challenge = ChallengeHelpers.create_single_phase_challenge(user, %{user_id: user.id})
 
       SolutionHelpers.create_submitted_solution(%{}, user, challenge)
 
@@ -286,7 +295,7 @@ defmodule ChallengeGov.SolutionsTest do
     test "filter by submitter id" do
       user = AccountHelpers.create_user()
       user_2 = AccountHelpers.create_user(%{email: "user_2@example.com"})
-      challenge = ChallengeHelpers.create_challenge(%{user_id: user.id})
+      challenge = ChallengeHelpers.create_single_phase_challenge(user, %{user_id: user.id})
 
       SolutionHelpers.create_submitted_solution(%{}, user_2, challenge)
 
@@ -305,8 +314,8 @@ defmodule ChallengeGov.SolutionsTest do
 
     test "filter by challenge id" do
       user = AccountHelpers.create_user()
-      challenge = ChallengeHelpers.create_challenge(%{user_id: user.id})
-      challenge_2 = ChallengeHelpers.create_challenge(%{user_id: user.id})
+      challenge = ChallengeHelpers.create_single_phase_challenge(user, %{user_id: user.id})
+      challenge_2 = ChallengeHelpers.create_single_phase_challenge(user, %{user_id: user.id})
 
       SolutionHelpers.create_submitted_solution(%{}, user, challenge_2)
 
@@ -325,7 +334,7 @@ defmodule ChallengeGov.SolutionsTest do
 
     test "filter by search param" do
       user = AccountHelpers.create_user()
-      challenge = ChallengeHelpers.create_challenge(%{user_id: user.id})
+      challenge = ChallengeHelpers.create_single_phase_challenge(user, %{user_id: user.id})
 
       SolutionHelpers.create_submitted_solution(%{}, user, challenge)
 
@@ -416,7 +425,7 @@ defmodule ChallengeGov.SolutionsTest do
 
     test "filter by title" do
       user = AccountHelpers.create_user()
-      challenge = ChallengeHelpers.create_challenge(%{user_id: user.id})
+      challenge = ChallengeHelpers.create_single_phase_challenge(user, %{user_id: user.id})
 
       SolutionHelpers.create_submitted_solution(
         %{
@@ -448,7 +457,7 @@ defmodule ChallengeGov.SolutionsTest do
 
     test "filter by brief description" do
       user = AccountHelpers.create_user()
-      challenge = ChallengeHelpers.create_challenge(%{user_id: user.id})
+      challenge = ChallengeHelpers.create_single_phase_challenge(user, %{user_id: user.id})
 
       SolutionHelpers.create_submitted_solution(
         %{
@@ -480,7 +489,7 @@ defmodule ChallengeGov.SolutionsTest do
 
     test "filter by description" do
       user = AccountHelpers.create_user()
-      challenge = ChallengeHelpers.create_challenge(%{user_id: user.id})
+      challenge = ChallengeHelpers.create_single_phase_challenge(user, %{user_id: user.id})
 
       SolutionHelpers.create_submitted_solution(
         %{
@@ -512,7 +521,7 @@ defmodule ChallengeGov.SolutionsTest do
 
     test "filter by external url" do
       user = AccountHelpers.create_user()
-      challenge = ChallengeHelpers.create_challenge(%{user_id: user.id})
+      challenge = ChallengeHelpers.create_single_phase_challenge(user, %{user_id: user.id})
 
       SolutionHelpers.create_submitted_solution(
         %{
@@ -546,7 +555,7 @@ defmodule ChallengeGov.SolutionsTest do
   describe "fetching a solution" do
     test "successfully by id" do
       user = AccountHelpers.create_user()
-      challenge = ChallengeHelpers.create_challenge(%{user_id: user.id})
+      challenge = ChallengeHelpers.create_single_phase_challenge(user, %{user_id: user.id})
 
       solution = SolutionHelpers.create_submitted_solution(%{}, user, challenge)
 
@@ -557,7 +566,7 @@ defmodule ChallengeGov.SolutionsTest do
 
     test "not found because of deletion" do
       user = AccountHelpers.create_user()
-      challenge = ChallengeHelpers.create_challenge(%{user_id: user.id})
+      challenge = ChallengeHelpers.create_single_phase_challenge(user, %{user_id: user.id})
 
       solution = SolutionHelpers.create_submitted_solution(%{}, user, challenge)
 
@@ -574,10 +583,10 @@ defmodule ChallengeGov.SolutionsTest do
   describe "security log" do
     test "tracks an event when a solution is submitted" do
       user = AccountHelpers.create_user()
-      challenge = ChallengeHelpers.create_challenge(%{user_id: user.id})
+      challenge = ChallengeHelpers.create_single_phase_challenge(user, %{user_id: user.id})
       solution = SolutionHelpers.create_submitted_solution(%{}, user, challenge)
 
-      log_event = List.first(SecurityLogs.all())
+      log_event = Enum.at(SecurityLogs.all(), 1)
 
       assert log_event.action === "submit"
       assert log_event.originator_id === user.id

--- a/test/challenge_gov/solutions_test.exs
+++ b/test/challenge_gov/solutions_test.exs
@@ -580,6 +580,43 @@ defmodule ChallengeGov.SolutionsTest do
     end
   end
 
+  describe "updating judging status" do
+    test "success: changing from unselected to selected" do
+      user = AccountHelpers.create_user()
+      challenge = ChallengeHelpers.create_single_phase_challenge(user, %{user_id: user.id})
+
+      solution = SolutionHelpers.create_submitted_solution(%{}, user, challenge)
+
+      {:ok, updated_solution} = Solutions.update_judging_status(solution, "select")
+
+      assert solution.judging_status === "not_selected"
+      assert updated_solution.judging_status === "selected"
+    end
+
+    test "success: changing from selected to unselected" do
+      user = AccountHelpers.create_user()
+      challenge = ChallengeHelpers.create_single_phase_challenge(user, %{user_id: user.id})
+
+      solution = SolutionHelpers.create_submitted_solution(%{}, user, challenge)
+
+      {:ok, updated_solution} = Solutions.update_judging_status(solution, "select")
+      assert updated_solution.judging_status === "selected"
+
+      {:ok, unselected_solution} = Solutions.update_judging_status(updated_solution, "unselect")
+      assert unselected_solution.judging_status === "not_selected"
+    end
+
+    test "failure: with invalid status" do
+      user = AccountHelpers.create_user()
+      challenge = ChallengeHelpers.create_single_phase_challenge(user, %{user_id: user.id})
+
+      solution = SolutionHelpers.create_submitted_solution(%{}, user, challenge)
+
+      assert {:error, :invalid_judging_status} ===
+               Solutions.update_judging_status(solution, "invalid")
+    end
+  end
+
   describe "security log" do
     test "tracks an event when a solution is submitted" do
       user = AccountHelpers.create_user()

--- a/test/support/test_helpers/challenge_helpers.ex
+++ b/test/support/test_helpers/challenge_helpers.ex
@@ -82,6 +82,35 @@ defmodule ChallengeGov.TestHelpers.ChallengeHelpers do
     challenge
   end
 
+  def create_closed_single_phase_challenge(user, attributes \\ %{}) do
+    challenge = create_challenge(attributes, user)
+
+    {:ok, challenge} =
+      Challenges.update(
+        challenge,
+        %{
+          "action" => "next",
+          "challenge" => %{
+            "section" => "details",
+            "challenge_title" => challenge.title,
+            "upload_logo" => "false",
+            "is_multi_phase" => "false",
+            "phases" => %{
+              "0" => %{
+                "start_date" => TestHelpers.iso_timestamp(hours: -2),
+                "end_date" => TestHelpers.iso_timestamp(hours: -1),
+                "open_to_submissions" => "true"
+              }
+            }
+          }
+        },
+        user,
+        ""
+      )
+
+    challenge
+  end
+
   def create_multi_phase_challenge(user, attributes \\ %{}) do
     challenge = create_challenge(attributes, user)
 

--- a/test/support/test_helpers/solution_helpers.ex
+++ b/test/support/test_helpers/solution_helpers.ex
@@ -18,28 +18,34 @@ defmodule ChallengeGov.TestHelpers.SolutionHelpers do
     )
   end
 
-  def create_draft_solution(attributes \\ %{}, user, challenge) do
+  def create_draft_solution(attributes \\ %{}, user, challenge, phase \\ nil) do
+    phase = phase || Enum.at(challenge.phases, 0)
+
     {:ok, solution} =
       %Solution{}
-      |> Solution.draft_changeset(default_attributes(attributes), user, challenge)
+      |> Solution.draft_changeset(default_attributes(attributes), user, challenge, phase)
       |> Repo.insert()
 
     solution
   end
 
-  def create_review_solution(attributes \\ %{}, user, challenge) do
+  def create_review_solution(attributes \\ %{}, user, challenge, phase \\ nil) do
+    phase = phase || Enum.at(challenge.phases, 0)
+
     {:ok, solution} =
       %Solution{}
-      |> Solution.review_changeset(default_attributes(attributes), user, challenge)
+      |> Solution.review_changeset(default_attributes(attributes), user, challenge, phase)
       |> Repo.insert()
 
     solution
   end
 
-  def create_submitted_solution(attributes \\ %{}, user, challenge) do
+  def create_submitted_solution(attributes \\ %{}, user, challenge, phase \\ nil) do
+    phase = phase || Enum.at(challenge.phases, 0)
+
     {:ok, solution} =
       attributes
-      |> create_review_solution(user, challenge)
+      |> create_review_solution(user, challenge, phase)
       |> Solutions.submit()
 
     solution

--- a/test/web/controllers/phase_controller_test.exs
+++ b/test/web/controllers/phase_controller_test.exs
@@ -1,0 +1,278 @@
+defmodule Web.PhaseControllerTest do
+  use Web.ConnCase
+
+  alias ChallengeGov.TestHelpers.AccountHelpers
+  alias ChallengeGov.TestHelpers.ChallengeHelpers
+
+  describe "index for a challenge" do
+    test "success: as super admin", %{conn: conn} do
+      user = AccountHelpers.create_user(%{role: "super_admin"})
+      conn = prep_conn(conn, user)
+
+      user2 = AccountHelpers.create_user(%{email: "user2@example.com", role: "challenge_owner"})
+      challenge = ChallengeHelpers.create_single_phase_challenge(user2, %{user_id: user2.id})
+      _challenge_2 = ChallengeHelpers.create_single_phase_challenge(user2, %{user_id: user2.id})
+
+      conn = get(conn, Routes.challenge_phase_path(conn, :index, challenge.id))
+
+      %{
+        user: user_in_assigns,
+        phases: phases
+      } = conn.assigns
+
+      assert user === user_in_assigns
+
+      assert length(phases) === 1
+
+      assert html_response(conn, 200)
+    end
+
+    test "success: as admin", %{conn: conn} do
+      user = AccountHelpers.create_user(%{role: "admin"})
+      conn = prep_conn(conn, user)
+
+      user2 = AccountHelpers.create_user(%{email: "user2@example.com", role: "challenge_owner"})
+      challenge = ChallengeHelpers.create_single_phase_challenge(user2, %{user_id: user2.id})
+      _challenge_2 = ChallengeHelpers.create_single_phase_challenge(user2, %{user_id: user2.id})
+
+      conn = get(conn, Routes.challenge_phase_path(conn, :index, challenge.id))
+
+      %{
+        user: user_in_assigns,
+        phases: phases
+      } = conn.assigns
+
+      assert user === user_in_assigns
+
+      assert length(phases) === 1
+
+      assert html_response(conn, 200)
+    end
+
+    test "success: as challenge owner of challenge", %{conn: conn} do
+      user = AccountHelpers.create_user(%{role: "challenge_owner"})
+      conn = prep_conn(conn, user)
+
+      challenge = ChallengeHelpers.create_single_phase_challenge(user, %{user_id: user.id})
+      _challenge_2 = ChallengeHelpers.create_single_phase_challenge(user, %{user_id: user.id})
+
+      conn = get(conn, Routes.challenge_phase_path(conn, :index, challenge.id))
+
+      %{
+        user: user_in_assigns,
+        phases: phases
+      } = conn.assigns
+
+      assert user === user_in_assigns
+
+      assert length(phases) === 1
+
+      assert html_response(conn, 200)
+    end
+
+    test "failure: challenge not found", %{conn: conn} do
+      user = AccountHelpers.create_user(%{role: "challenge_owner"})
+      conn = prep_conn(conn, user)
+
+      conn = get(conn, Routes.challenge_phase_path(conn, :index, -1))
+
+      %{
+        user: user_in_assigns
+      } = conn.assigns
+
+      assert user === user_in_assigns
+      assert conn.status === 302
+      assert get_flash(conn, :error) === "Challenge not found"
+      assert redirected_to(conn) == Routes.challenge_path(conn, :index)
+    end
+
+    test "failure: as a different challenge owner", %{conn: conn} do
+      user = AccountHelpers.create_user(%{role: "challenge_owner"})
+      conn = prep_conn(conn, user)
+
+      user2 = AccountHelpers.create_user(%{email: "user2@example.com", role: "challenge_owner"})
+      challenge = ChallengeHelpers.create_single_phase_challenge(user2, %{user_id: user2.id})
+      _challenge_2 = ChallengeHelpers.create_single_phase_challenge(user2, %{user_id: user2.id})
+
+      conn = get(conn, Routes.challenge_phase_path(conn, :index, challenge.id))
+
+      %{
+        user: user_in_assigns
+      } = conn.assigns
+
+      assert user === user_in_assigns
+
+      assert conn.status === 302
+      assert get_flash(conn, :error) === "You are not allowed to view this challenge's phases"
+      assert redirected_to(conn) == Routes.challenge_path(conn, :index)
+    end
+
+    test "failure: as solver", %{conn: conn} do
+      user = AccountHelpers.create_user(%{role: "solver"})
+      conn = prep_conn(conn, user)
+
+      user2 = AccountHelpers.create_user(%{email: "user2@example.com", role: "challenge_owner"})
+      challenge = ChallengeHelpers.create_single_phase_challenge(user2, %{user_id: user2.id})
+      _challenge_2 = ChallengeHelpers.create_single_phase_challenge(user2, %{user_id: user2.id})
+
+      conn = get(conn, Routes.challenge_phase_path(conn, :index, challenge.id))
+
+      %{
+        current_user: user_in_assigns
+      } = conn.assigns
+
+      assert user === user_in_assigns
+
+      assert conn.status === 302
+      assert get_flash(conn, :error) === "You are not authorized"
+      assert redirected_to(conn) == Routes.dashboard_path(conn, :index)
+    end
+  end
+
+  describe "show for a phase" do
+    test "success: as super admin", %{conn: conn} do
+      user = AccountHelpers.create_user(%{role: "super_admin"})
+      conn = prep_conn(conn, user)
+
+      user2 = AccountHelpers.create_user(%{email: "user2@example.com", role: "challenge_owner"})
+      challenge = ChallengeHelpers.create_single_phase_challenge(user2, %{user_id: user2.id})
+
+      phase = Enum.at(challenge.phases, 0)
+
+      conn = get(conn, Routes.challenge_phase_path(conn, :show, challenge.id, phase.id))
+
+      %{
+        user: user_in_assigns,
+        phase: phase_in_assigns
+      } = conn.assigns
+
+      assert user === user_in_assigns
+      assert phase === phase_in_assigns
+      assert html_response(conn, 200)
+    end
+
+    test "success: as admin", %{conn: conn} do
+      user = AccountHelpers.create_user(%{role: "admin"})
+      conn = prep_conn(conn, user)
+
+      user2 = AccountHelpers.create_user(%{email: "user2@example.com", role: "challenge_owner"})
+      challenge = ChallengeHelpers.create_single_phase_challenge(user2, %{user_id: user2.id})
+
+      phase = Enum.at(challenge.phases, 0)
+
+      conn = get(conn, Routes.challenge_phase_path(conn, :show, challenge.id, phase.id))
+
+      %{
+        user: user_in_assigns,
+        phase: phase_in_assigns
+      } = conn.assigns
+
+      assert user === user_in_assigns
+      assert phase === phase_in_assigns
+      assert html_response(conn, 200)
+    end
+
+    test "success: as challenge owner of challenge", %{conn: conn} do
+      user = AccountHelpers.create_user(%{role: "challenge_owner"})
+      conn = prep_conn(conn, user)
+
+      challenge = ChallengeHelpers.create_single_phase_challenge(user, %{user_id: user.id})
+
+      phase = Enum.at(challenge.phases, 0)
+
+      conn = get(conn, Routes.challenge_phase_path(conn, :show, challenge.id, phase.id))
+
+      %{
+        user: user_in_assigns,
+        phase: phase_in_assigns
+      } = conn.assigns
+
+      assert user === user_in_assigns
+      assert phase === phase_in_assigns
+      assert html_response(conn, 200)
+    end
+
+    test "failure: challenge not found", %{conn: conn} do
+      user = AccountHelpers.create_user(%{role: "challenge_owner"})
+      conn = prep_conn(conn, user)
+
+      conn = get(conn, Routes.challenge_phase_path(conn, :show, -1, -1))
+
+      %{
+        user: user_in_assigns
+      } = conn.assigns
+
+      assert user === user_in_assigns
+      assert conn.status === 302
+      assert get_flash(conn, :error) === "Phase not found"
+      assert redirected_to(conn) == Routes.challenge_path(conn, :index)
+    end
+
+    test "failure: phase not found", %{conn: conn} do
+      user = AccountHelpers.create_user(%{role: "challenge_owner"})
+      conn = prep_conn(conn, user)
+
+      challenge = ChallengeHelpers.create_single_phase_challenge(user, %{user_id: user.id})
+
+      conn = get(conn, Routes.challenge_phase_path(conn, :show, challenge.id, -1))
+
+      %{
+        user: user_in_assigns
+      } = conn.assigns
+
+      assert user === user_in_assigns
+      assert conn.status === 302
+      assert get_flash(conn, :error) === "Phase not found"
+      assert redirected_to(conn) == Routes.challenge_path(conn, :index)
+    end
+
+    test "failure: as a different challenge owner", %{conn: conn} do
+      user = AccountHelpers.create_user(%{role: "challenge_owner"})
+      conn = prep_conn(conn, user)
+
+      user2 = AccountHelpers.create_user(%{email: "user2@example.com", role: "challenge_owner"})
+      challenge = ChallengeHelpers.create_single_phase_challenge(user2, %{user_id: user2.id})
+      _challenge_2 = ChallengeHelpers.create_single_phase_challenge(user2, %{user_id: user2.id})
+
+      phase = Enum.at(challenge.phases, 0)
+
+      conn = get(conn, Routes.challenge_phase_path(conn, :show, challenge.id, phase.id))
+
+      %{
+        user: user_in_assigns
+      } = conn.assigns
+
+      assert user === user_in_assigns
+      assert conn.status === 302
+      assert get_flash(conn, :error) === "You are not allowed to view this phase"
+      assert redirected_to(conn) == Routes.challenge_path(conn, :index)
+    end
+
+    test "failure: as a solver", %{conn: conn} do
+      user = AccountHelpers.create_user(%{role: "solver"})
+      conn = prep_conn(conn, user)
+
+      user2 = AccountHelpers.create_user(%{email: "user2@example.com", role: "challenge_owner"})
+      challenge = ChallengeHelpers.create_single_phase_challenge(user2, %{user_id: user2.id})
+      _challenge_2 = ChallengeHelpers.create_single_phase_challenge(user2, %{user_id: user2.id})
+
+      phase = Enum.at(challenge.phases, 0)
+
+      conn = get(conn, Routes.challenge_phase_path(conn, :show, challenge.id, phase.id))
+
+      %{
+        current_user: user_in_assigns
+      } = conn.assigns
+
+      assert user === user_in_assigns
+
+      assert conn.status === 302
+      assert get_flash(conn, :error) === "You are not authorized"
+      assert redirected_to(conn) == Routes.dashboard_path(conn, :index)
+    end
+  end
+
+  defp prep_conn(conn, user) do
+    assign(conn, :current_user, user)
+  end
+end

--- a/test/web/controllers/phase_controller_test.exs
+++ b/test/web/controllers/phase_controller_test.exs
@@ -1,7 +1,6 @@
 defmodule Web.PhaseControllerTest do
   use Web.ConnCase
 
-  alias ChallengeGov.Repo
   alias ChallengeGov.TestHelpers.AccountHelpers
   alias ChallengeGov.TestHelpers.ChallengeHelpers
 
@@ -138,10 +137,7 @@ defmodule Web.PhaseControllerTest do
       user2 = AccountHelpers.create_user(%{email: "user2@example.com", role: "challenge_owner"})
       challenge = ChallengeHelpers.create_single_phase_challenge(user2, %{user_id: user2.id})
 
-      phase =
-        challenge.phases
-        |> Enum.at(0)
-        |> Repo.preload([:solutions])
+      phase = Enum.at(challenge.phases, 0)
 
       conn = get(conn, Routes.challenge_phase_path(conn, :show, challenge.id, phase.id))
 
@@ -151,7 +147,7 @@ defmodule Web.PhaseControllerTest do
       } = conn.assigns
 
       assert user === user_in_assigns
-      assert phase === phase_in_assigns
+      assert phase.id === phase_in_assigns.id
       assert html_response(conn, 200)
     end
 
@@ -162,10 +158,7 @@ defmodule Web.PhaseControllerTest do
       user2 = AccountHelpers.create_user(%{email: "user2@example.com", role: "challenge_owner"})
       challenge = ChallengeHelpers.create_single_phase_challenge(user2, %{user_id: user2.id})
 
-      phase =
-        challenge.phases
-        |> Enum.at(0)
-        |> Repo.preload([:solutions])
+      phase = Enum.at(challenge.phases, 0)
 
       conn = get(conn, Routes.challenge_phase_path(conn, :show, challenge.id, phase.id))
 
@@ -175,7 +168,7 @@ defmodule Web.PhaseControllerTest do
       } = conn.assigns
 
       assert user === user_in_assigns
-      assert phase === phase_in_assigns
+      assert phase.id === phase_in_assigns.id
       assert html_response(conn, 200)
     end
 
@@ -185,10 +178,7 @@ defmodule Web.PhaseControllerTest do
 
       challenge = ChallengeHelpers.create_single_phase_challenge(user, %{user_id: user.id})
 
-      phase =
-        challenge.phases
-        |> Enum.at(0)
-        |> Repo.preload([:solutions])
+      phase = Enum.at(challenge.phases, 0)
 
       conn = get(conn, Routes.challenge_phase_path(conn, :show, challenge.id, phase.id))
 
@@ -198,7 +188,7 @@ defmodule Web.PhaseControllerTest do
       } = conn.assigns
 
       assert user === user_in_assigns
-      assert phase === phase_in_assigns
+      assert phase.id === phase_in_assigns.id
       assert html_response(conn, 200)
     end
 

--- a/test/web/controllers/phase_controller_test.exs
+++ b/test/web/controllers/phase_controller_test.exs
@@ -1,6 +1,7 @@
 defmodule Web.PhaseControllerTest do
   use Web.ConnCase
 
+  alias ChallengeGov.Repo
   alias ChallengeGov.TestHelpers.AccountHelpers
   alias ChallengeGov.TestHelpers.ChallengeHelpers
 
@@ -137,7 +138,10 @@ defmodule Web.PhaseControllerTest do
       user2 = AccountHelpers.create_user(%{email: "user2@example.com", role: "challenge_owner"})
       challenge = ChallengeHelpers.create_single_phase_challenge(user2, %{user_id: user2.id})
 
-      phase = Enum.at(challenge.phases, 0)
+      phase =
+        challenge.phases
+        |> Enum.at(0)
+        |> Repo.preload([:solutions])
 
       conn = get(conn, Routes.challenge_phase_path(conn, :show, challenge.id, phase.id))
 
@@ -158,7 +162,10 @@ defmodule Web.PhaseControllerTest do
       user2 = AccountHelpers.create_user(%{email: "user2@example.com", role: "challenge_owner"})
       challenge = ChallengeHelpers.create_single_phase_challenge(user2, %{user_id: user2.id})
 
-      phase = Enum.at(challenge.phases, 0)
+      phase =
+        challenge.phases
+        |> Enum.at(0)
+        |> Repo.preload([:solutions])
 
       conn = get(conn, Routes.challenge_phase_path(conn, :show, challenge.id, phase.id))
 
@@ -178,7 +185,10 @@ defmodule Web.PhaseControllerTest do
 
       challenge = ChallengeHelpers.create_single_phase_challenge(user, %{user_id: user.id})
 
-      phase = Enum.at(challenge.phases, 0)
+      phase =
+        challenge.phases
+        |> Enum.at(0)
+        |> Repo.preload([:solutions])
 
       conn = get(conn, Routes.challenge_phase_path(conn, :show, challenge.id, phase.id))
 

--- a/test/web/controllers/solution_controller_test.exs
+++ b/test/web/controllers/solution_controller_test.exs
@@ -11,8 +11,8 @@ defmodule Web.SolutionControllerTest do
       conn = prep_conn(conn)
       %{current_user: user} = conn.assigns
 
-      challenge = ChallengeHelpers.create_challenge(%{user_id: user.id})
-      challenge_2 = ChallengeHelpers.create_challenge(%{user_id: user.id})
+      challenge = ChallengeHelpers.create_single_phase_challenge(user, %{user_id: user.id})
+      challenge_2 = ChallengeHelpers.create_single_phase_challenge(user, %{user_id: user.id})
 
       SolutionHelpers.create_submitted_solution(%{}, user, challenge)
 
@@ -29,8 +29,8 @@ defmodule Web.SolutionControllerTest do
       conn = prep_conn(conn)
       %{current_user: user} = conn.assigns
 
-      challenge = ChallengeHelpers.create_challenge(%{user_id: user.id})
-      challenge_2 = ChallengeHelpers.create_challenge(%{user_id: user.id})
+      challenge = ChallengeHelpers.create_single_phase_challenge(user, %{user_id: user.id})
+      challenge_2 = ChallengeHelpers.create_single_phase_challenge(user, %{user_id: user.id})
 
       SolutionHelpers.create_submitted_solution(
         %{
@@ -64,7 +64,7 @@ defmodule Web.SolutionControllerTest do
 
     test "redirect to sign in when signed out", %{conn: conn} do
       user = AccountHelpers.create_user()
-      challenge = ChallengeHelpers.create_challenge(%{user_id: user.id})
+      challenge = ChallengeHelpers.create_single_phase_challenge(user, %{user_id: user.id})
       conn = get(conn, Routes.challenge_solution_path(conn, :index, challenge.id))
 
       assert conn.status === 302
@@ -77,7 +77,7 @@ defmodule Web.SolutionControllerTest do
       conn = prep_conn(conn)
       %{current_user: user} = conn.assigns
 
-      challenge = ChallengeHelpers.create_challenge(%{user_id: user.id})
+      challenge = ChallengeHelpers.create_single_phase_challenge(user, %{user_id: user.id})
 
       solution =
         SolutionHelpers.create_submitted_solution(
@@ -98,7 +98,7 @@ defmodule Web.SolutionControllerTest do
       conn = prep_conn(conn)
       %{current_user: user} = conn.assigns
 
-      challenge = ChallengeHelpers.create_challenge(%{user_id: user.id})
+      challenge = ChallengeHelpers.create_single_phase_challenge(user, %{user_id: user.id})
 
       solution = SolutionHelpers.create_submitted_solution(%{}, user, challenge)
 
@@ -115,7 +115,7 @@ defmodule Web.SolutionControllerTest do
       conn = prep_conn(conn)
       %{current_user: user} = conn.assigns
 
-      challenge = ChallengeHelpers.create_challenge(%{user_id: user.id})
+      challenge = ChallengeHelpers.create_single_phase_challenge(user, %{user_id: user.id})
 
       conn = get(conn, Routes.challenge_solution_path(conn, :new, challenge.id))
 
@@ -130,7 +130,7 @@ defmodule Web.SolutionControllerTest do
       conn = prep_conn(conn)
       %{current_user: user} = conn.assigns
 
-      challenge = ChallengeHelpers.create_challenge(%{user_id: user.id})
+      challenge = ChallengeHelpers.create_single_phase_challenge(user, %{user_id: user.id})
 
       params = %{
         "action" => "draft",
@@ -149,7 +149,7 @@ defmodule Web.SolutionControllerTest do
       conn = prep_conn(conn)
       %{current_user: user} = conn.assigns
 
-      challenge = ChallengeHelpers.create_challenge(%{user_id: user.id})
+      challenge = ChallengeHelpers.create_single_phase_challenge(user, %{user_id: user.id})
 
       params = %{
         "action" => "review",
@@ -171,7 +171,7 @@ defmodule Web.SolutionControllerTest do
       conn = prep_conn(conn)
       %{current_user: user} = conn.assigns
 
-      challenge = ChallengeHelpers.create_challenge(%{user_id: user.id})
+      challenge = ChallengeHelpers.create_single_phase_challenge(user, %{user_id: user.id})
 
       params = %{
         "action" => "review",
@@ -194,7 +194,7 @@ defmodule Web.SolutionControllerTest do
       conn = prep_conn(conn)
       %{current_user: user} = conn.assigns
 
-      challenge = ChallengeHelpers.create_challenge(%{user_id: user.id})
+      challenge = ChallengeHelpers.create_single_phase_challenge(user, %{user_id: user.id})
 
       solution = SolutionHelpers.create_draft_solution(%{}, user, challenge)
 
@@ -210,7 +210,7 @@ defmodule Web.SolutionControllerTest do
       conn = prep_conn(conn)
       %{current_user: user} = conn.assigns
 
-      challenge = ChallengeHelpers.create_challenge(%{user_id: user.id})
+      challenge = ChallengeHelpers.create_single_phase_challenge(user, %{user_id: user.id})
 
       solution = SolutionHelpers.create_submitted_solution(%{}, user, challenge)
 
@@ -227,7 +227,7 @@ defmodule Web.SolutionControllerTest do
       %{current_user: user} = conn.assigns
       user_2 = AccountHelpers.create_user(%{email: "user_2@example.com"})
 
-      challenge = ChallengeHelpers.create_challenge(%{user_id: user.id})
+      challenge = ChallengeHelpers.create_single_phase_challenge(user, %{user_id: user.id})
 
       solution = SolutionHelpers.create_submitted_solution(%{}, user_2, challenge)
 
@@ -241,7 +241,7 @@ defmodule Web.SolutionControllerTest do
       conn = prep_conn(conn)
       %{current_user: user} = conn.assigns
 
-      challenge = ChallengeHelpers.create_challenge(%{user_id: user.id})
+      challenge = ChallengeHelpers.create_single_phase_challenge(user, %{user_id: user.id})
 
       solution = SolutionHelpers.create_draft_solution(%{}, user, challenge)
 
@@ -268,7 +268,7 @@ defmodule Web.SolutionControllerTest do
       conn = prep_conn(conn)
       %{current_user: user} = conn.assigns
 
-      challenge = ChallengeHelpers.create_challenge(%{user_id: user.id})
+      challenge = ChallengeHelpers.create_single_phase_challenge(user, %{user_id: user.id})
 
       solution = SolutionHelpers.create_draft_solution(%{}, user, challenge)
 
@@ -295,7 +295,7 @@ defmodule Web.SolutionControllerTest do
       conn = prep_conn(conn)
       %{current_user: user} = conn.assigns
 
-      challenge = ChallengeHelpers.create_challenge(%{user_id: user.id})
+      challenge = ChallengeHelpers.create_single_phase_challenge(user, %{user_id: user.id})
 
       solution = SolutionHelpers.create_submitted_solution(%{}, user, challenge)
 
@@ -322,7 +322,7 @@ defmodule Web.SolutionControllerTest do
       conn = prep_conn(conn)
       %{current_user: user} = conn.assigns
 
-      challenge = ChallengeHelpers.create_challenge(%{user_id: user.id})
+      challenge = ChallengeHelpers.create_single_phase_challenge(user, %{user_id: user.id})
 
       solution = SolutionHelpers.create_submitted_solution(%{}, user, challenge)
 
@@ -347,7 +347,7 @@ defmodule Web.SolutionControllerTest do
       conn = prep_conn(conn)
       %{current_user: user} = conn.assigns
 
-      challenge = ChallengeHelpers.create_challenge(%{user_id: user.id})
+      challenge = ChallengeHelpers.create_single_phase_challenge(user, %{user_id: user.id})
 
       solution = SolutionHelpers.create_submitted_solution(%{}, user, challenge)
 
@@ -374,7 +374,7 @@ defmodule Web.SolutionControllerTest do
       %{current_user: user} = conn.assigns
       user_2 = AccountHelpers.create_user(%{email: "user_2@example.com"})
 
-      challenge = ChallengeHelpers.create_challenge(%{user_id: user.id})
+      challenge = ChallengeHelpers.create_single_phase_challenge(user, %{user_id: user.id})
 
       solution = SolutionHelpers.create_submitted_solution(%{}, user_2, challenge)
 
@@ -398,7 +398,7 @@ defmodule Web.SolutionControllerTest do
       conn = prep_conn(conn)
       %{current_user: user} = conn.assigns
 
-      challenge = ChallengeHelpers.create_challenge(%{user_id: user.id})
+      challenge = ChallengeHelpers.create_single_phase_challenge(user, %{user_id: user.id})
 
       solution = SolutionHelpers.create_draft_solution(%{}, user, challenge)
 
@@ -414,7 +414,7 @@ defmodule Web.SolutionControllerTest do
       conn = prep_conn(conn)
       %{current_user: user} = conn.assigns
 
-      challenge = ChallengeHelpers.create_challenge(%{user_id: user.id})
+      challenge = ChallengeHelpers.create_single_phase_challenge(user, %{user_id: user.id})
 
       solution = SolutionHelpers.create_submitted_solution(%{}, user, challenge)
 
@@ -461,7 +461,7 @@ defmodule Web.SolutionControllerTest do
       conn = prep_conn(conn)
       %{current_user: user} = conn.assigns
 
-      challenge = ChallengeHelpers.create_challenge(%{user_id: user.id})
+      challenge = ChallengeHelpers.create_single_phase_challenge(user, %{user_id: user.id})
 
       solution = SolutionHelpers.create_draft_solution(%{}, user, challenge)
 
@@ -476,7 +476,7 @@ defmodule Web.SolutionControllerTest do
       conn = prep_conn(conn)
       %{current_user: user} = conn.assigns
 
-      challenge = ChallengeHelpers.create_challenge(%{user_id: user.id})
+      challenge = ChallengeHelpers.create_single_phase_challenge(user, %{user_id: user.id})
 
       solution = SolutionHelpers.create_submitted_solution(%{}, user, challenge)
 
@@ -493,7 +493,7 @@ defmodule Web.SolutionControllerTest do
 
       user_2 = AccountHelpers.create_user()
 
-      challenge = ChallengeHelpers.create_challenge(%{user_id: user.id})
+      challenge = ChallengeHelpers.create_single_phase_challenge(user, %{user_id: user.id})
 
       solution = SolutionHelpers.create_draft_solution(%{}, user_2, challenge)
 
@@ -510,7 +510,7 @@ defmodule Web.SolutionControllerTest do
 
       user_2 = AccountHelpers.create_user()
 
-      challenge = ChallengeHelpers.create_challenge(%{user_id: user.id})
+      challenge = ChallengeHelpers.create_single_phase_challenge(user, %{user_id: user.id})
 
       solution = SolutionHelpers.create_submitted_solution(%{}, user_2, challenge)
 
@@ -525,7 +525,7 @@ defmodule Web.SolutionControllerTest do
       conn = prep_conn(conn)
       %{current_user: user} = conn.assigns
 
-      challenge = ChallengeHelpers.create_challenge(%{user_id: user.id})
+      challenge = ChallengeHelpers.create_single_phase_challenge(user, %{user_id: user.id})
 
       solution = SolutionHelpers.create_submitted_solution(%{}, user, challenge)
 


### PR DESCRIPTION
Cards: 411, 416, 418

- Phase solution management pages
- Ability to select a solution for judging
- Solutions/submissions will now get attached to the current phase of a challenge when creating a solution and should error if there is not current phase