### PR TITLE
Disallow submission exports with non closed phases

### DIFF
--- a/lib/challenge_gov/challenges.ex
+++ b/lib/challenge_gov/challenges.ex
@@ -792,6 +792,15 @@ defmodule ChallengeGov.Challenges do
   end
 
   @doc """
+  Returns if a challenge has closed phases or not
+  """
+  def has_closed_phases?(%{phases: phases}) do
+    Enum.any?(phases, fn phase ->
+      Phases.is_past?(phase)
+    end)
+  end
+
+  @doc """
   Create a new status event when the status changes
   """
   def create_status_event(_), do: :ok

--- a/lib/challenge_gov/phases.ex
+++ b/lib/challenge_gov/phases.ex
@@ -59,6 +59,14 @@ defmodule ChallengeGov.Phases do
 
   def is_future?(_phase), do: false
 
+  def closed_for_challenge(challenge) do
+    now = DateTime.utc_now()
+
+    Phase
+    |> where([p], p.challenge_id == ^challenge.id and p.end_date < ^now)
+    |> Repo.all()
+  end
+
   def solution_count(phase, filter \\ %{}) do
     phase
     |> Ecto.assoc(:solutions)

--- a/lib/challenge_gov/solutions/submission_export.ex
+++ b/lib/challenge_gov/solutions/submission_export.ex
@@ -8,6 +8,7 @@ defmodule ChallengeGov.Solutions.SubmissionExport do
   import Ecto.Changeset
 
   alias ChallengeGov.Challenges.Challenge
+  alias ChallengeGov.Phases
 
   @type t :: %__MODULE__{}
 
@@ -60,6 +61,7 @@ defmodule ChallengeGov.Solutions.SubmissionExport do
       :judging_status,
       :format
     ])
+    |> validate_phases_closed(params)
   end
 
   def create_changeset(struct, params, challenge) do
@@ -71,5 +73,21 @@ defmodule ChallengeGov.Solutions.SubmissionExport do
   def update_changeset(struct, params) do
     struct
     |> changeset(params)
+  end
+
+  defp validate_phases_closed(struct, %{"phase_ids" => phase_ids}) do
+    phase_ids
+    |> Enum.map(fn phase_id ->
+      {:ok, phase} = Phases.get(phase_id)
+      Phases.is_past?(phase)
+    end)
+    |> Enum.all?()
+    |> case do
+      true ->
+        struct
+
+      false ->
+        add_error(struct, :phase_ids, "All phases must be closed")
+    end
   end
 end

--- a/lib/web/controllers/phase_controller.ex
+++ b/lib/web/controllers/phase_controller.ex
@@ -18,6 +18,7 @@ defmodule Web.PhaseController do
       |> assign(:user, user)
       |> assign(:challenge, challenge)
       |> assign(:phases, challenge.phases)
+      |> assign(:has_closed_phases, Challenges.has_closed_phases?(challenge))
       |> render("index.html")
     else
       {:error, :not_permitted} ->
@@ -72,6 +73,7 @@ defmodule Web.PhaseController do
       |> assign(:challenge, challenge)
       |> assign(:phase, phase)
       |> assign(:solutions, solutions)
+      |> assign(:has_closed_phases, Challenges.has_closed_phases?(challenge))
       |> assign(:pagination, pagination)
       |> assign(:sort, sort)
       |> assign(:filter, filter)

--- a/lib/web/templates/phase/index.html.eex
+++ b/lib/web/templates/phase/index.html.eex
@@ -21,11 +21,13 @@
       </div>
     </div>
 
-    <div class="row mb-2">
-      <div class="col">
-        <%= link "Download", to: Routes.submission_export_path(@conn, :index, @challenge.id), class: "btn btn-primary" %>
+    <%= if @has_closed_phases do %>
+      <div class="row mb-2">
+        <div class="col">
+          <%= link "Download", to: Routes.submission_export_path(@conn, :index, @challenge.id), class: "btn btn-primary" %>
+        </div>
       </div>
-    </div>
+    <% end %>
   </div>
 </div>
 

--- a/lib/web/templates/phase/show.html.eex
+++ b/lib/web/templates/phase/show.html.eex
@@ -48,11 +48,13 @@
     </div>
   </div>
 
-  <div class="row p-2 mb-1">
-    <div class="col">
-      <%= link "Download", to: Routes.submission_export_path(@conn, :index, @challenge.id), class: "btn btn-primary" %>
+  <%= if @has_closed_phases do %>
+    <div class="row p-2 mb-1">
+      <div class="col">
+        <%= link "Download", to: Routes.submission_export_path(@conn, :index, @challenge.id), class: "btn btn-primary" %>
+      </div>
     </div>
-  </div>
+  <% end %>
 </div>
 
 <%= render Web.PhaseView, "solution_table/_table.html", conn: @conn, user: @user, challenge: @challenge, phase: @phase, solutions: @solutions, pagination: @pagination, sort: @sort, filter: @filter %>

--- a/lib/web/templates/submission_export/index.html.eex
+++ b/lib/web/templates/submission_export/index.html.eex
@@ -22,9 +22,9 @@
       </div>
       <%= form_for @conn, Routes.submission_export_path(@conn, :create, @challenge.id), fn f -> %>
         <div class="modal-body">
-          <%= if length(@challenge.phases) > 1 do %>
+          <%= if length(@closed_phases) > 1 do %>
             <p>Choose challenge phases:</p>
-            <%= Enum.map(@challenge.phases, fn phase -> %>
+            <%= Enum.map(@closed_phases, fn phase -> %>
               <%= label do %>
                 <%= checkbox(f, "phase_ids[]", checked_value: phase.id, hidden_input: false) %>
                 <span class="ml-1"><%= phase.title %></span>

--- a/test/challenge_gov/submission_exports_test.exs
+++ b/test/challenge_gov/submission_exports_test.exs
@@ -8,7 +8,9 @@ defmodule ChallengeGov.SubmissionExportsTest do
   describe "exporting submissions" do
     test "success: all as zip" do
       user = AccountHelpers.create_user()
-      challenge = ChallengeHelpers.create_open_multi_phase_challenge(user, %{user_id: user.id})
+
+      challenge =
+        ChallengeHelpers.create_archived_multi_phase_challenge(user, %{user_id: user.id})
 
       phase_ids =
         Enum.map(challenge.phases, fn phase ->

--- a/test/web/controllers/submission_export_controller_test.exs
+++ b/test/web/controllers/submission_export_controller_test.exs
@@ -10,7 +10,9 @@ defmodule Web.SubmissionExportControllerTest do
       conn = prep_conn(conn, user)
 
       user2 = AccountHelpers.create_user(%{email: "user2@example.com", role: "challenge_owner"})
-      challenge = ChallengeHelpers.create_single_phase_challenge(user2, %{user_id: user2.id})
+
+      challenge =
+        ChallengeHelpers.create_closed_single_phase_challenge(user2, %{user_id: user2.id})
 
       conn = get(conn, Routes.submission_export_path(conn, :index, challenge.id))
 
@@ -28,7 +30,9 @@ defmodule Web.SubmissionExportControllerTest do
       conn = prep_conn(conn, user)
 
       user2 = AccountHelpers.create_user(%{email: "user2@example.com", role: "challenge_owner"})
-      challenge = ChallengeHelpers.create_single_phase_challenge(user2, %{user_id: user2.id})
+
+      challenge =
+        ChallengeHelpers.create_closed_single_phase_challenge(user2, %{user_id: user2.id})
 
       conn = get(conn, Routes.submission_export_path(conn, :index, challenge.id))
 
@@ -45,7 +49,7 @@ defmodule Web.SubmissionExportControllerTest do
       user = AccountHelpers.create_user(%{role: "challenge_owner"})
       conn = prep_conn(conn, user)
 
-      challenge = ChallengeHelpers.create_single_phase_challenge(user, %{user_id: user.id})
+      challenge = ChallengeHelpers.create_closed_single_phase_challenge(user, %{user_id: user.id})
 
       conn = get(conn, Routes.submission_export_path(conn, :index, challenge.id))
 
@@ -56,6 +60,18 @@ defmodule Web.SubmissionExportControllerTest do
       assert user === user_in_assigns
 
       assert html_response(conn, 200)
+    end
+
+    test "failure: challenge has no closed phases", %{conn: conn} do
+      user = AccountHelpers.create_user(%{role: "challenge_owner"})
+      conn = prep_conn(conn, user)
+
+      challenge = ChallengeHelpers.create_single_phase_challenge(user, %{user_id: user.id})
+
+      conn = get(conn, Routes.submission_export_path(conn, :index, challenge.id))
+
+      assert get_flash(conn, :error) == "Challenge has no closed phases to export"
+      assert html_response(conn, 302)
     end
 
     test "failure: challenge not found", %{conn: conn} do
@@ -106,6 +122,59 @@ defmodule Web.SubmissionExportControllerTest do
       assert conn.status === 302
       assert get_flash(conn, :error) === "You are not authorized"
       assert redirected_to(conn) == Routes.dashboard_path(conn, :index)
+    end
+  end
+
+  describe "create" do
+    test "success: creating a submission export", %{conn: conn} do
+      user = AccountHelpers.create_user(%{role: "super_admin"})
+      conn = prep_conn(conn, user)
+
+      user2 = AccountHelpers.create_user(%{email: "user2@example.com", role: "challenge_owner"})
+
+      challenge =
+        ChallengeHelpers.create_closed_single_phase_challenge(user2, %{user_id: user2.id})
+
+      phase_ids =
+        Enum.map(challenge.phases, fn phase ->
+          to_string(phase.id)
+        end)
+
+      params = %{
+        "phase_ids" => phase_ids,
+        "judging_status" => "all",
+        "format" => "csv"
+      }
+
+      conn = post(conn, Routes.submission_export_path(conn, :create, challenge.id), params)
+
+      assert get_flash(conn, :info) === "Submission export created"
+      assert redirected_to(conn) === Routes.submission_export_path(conn, :index, challenge.id)
+    end
+
+    test "failure: creating a submission export with no closed phases", %{conn: conn} do
+      user = AccountHelpers.create_user(%{role: "super_admin"})
+      conn = prep_conn(conn, user)
+
+      user2 = AccountHelpers.create_user(%{email: "user2@example.com", role: "challenge_owner"})
+
+      challenge = ChallengeHelpers.create_open_multi_phase_challenge(user2, %{user_id: user2.id})
+
+      phase_ids =
+        Enum.map(challenge.phases, fn phase ->
+          to_string(phase.id)
+        end)
+
+      params = %{
+        "phase_ids" => phase_ids,
+        "judging_status" => "all",
+        "format" => "csv"
+      }
+
+      conn = post(conn, Routes.submission_export_path(conn, :create, challenge.id), params)
+
+      assert get_flash(conn, :error) === "All phases must be closed"
+      assert redirected_to(conn) === Routes.submission_export_path(conn, :index, challenge.id)
     end
   end
 


### PR DESCRIPTION
CHAL-497

- Return an error when a submission export is going to be created with
  non closed phases
- Hide non closed phases from submission export modal
- Hide download button when a challenge has no closed phases
- Disallow viewing submission export index if the challenge has no
  closed phases