### PR TITLE
Check and prune duplicates for submission exports

### DIFF
--- a/lib/challenge_gov/submission_exports.ex
+++ b/lib/challenge_gov/submission_exports.ex
@@ -13,7 +13,7 @@ defmodule ChallengeGov.SubmissionExports do
   def all(challenge) do
     SubmissionExport
     |> where([se], se.challenge_id == ^challenge.id)
-    |> order_by([se], desc: se.inserted_at)
+    |> order_by([se], desc: se.updated_at)
     |> Repo.all()
   end
 
@@ -87,7 +87,13 @@ defmodule ChallengeGov.SubmissionExports do
 
   defp prune_duplicates(submission_exports) do
     if length(submission_exports) == 1 do
-      Enum.at(submission_exports, 0)
+      {:ok, submission_export} =
+        submission_exports
+        |> Enum.at(0)
+        |> Ecto.Changeset.change(%{updated_at: DateTime.utc_now()})
+        |> Repo.update()
+
+      submission_export
     else
       Enum.each(submission_exports, fn submission_export ->
         delete(submission_export)


### PR DESCRIPTION
Check phase_ids, judging_status, and format when creating a new
submission export. If one is found it will be triggered to export again.
If more than one is found it will be deleted. Otherwise create a new one