### PR TITLE
Submission invite email links. editor link disable

### DIFF
--- a/assets/js/app/_rich_text_editor.js
+++ b/assets/js/app/_rich_text_editor.js
@@ -3,23 +3,32 @@ import { QuillDeltaToHtmlConverter } from "quill-delta-to-html"
 
 // Rich text generator
 let toolbarOptions = [
-  ['bold', 'italic', 'underline', 'strike'],        // toggled buttons
-  ['blockquote', 'code-block'],
+  // Additional options
+  // ['bold', 'italic', 'underline', 'strike'],        // toggled buttons
+  // ['blockquote', 'code-block'],
+  // [{ 'header': 1 }, { 'header': 2 }],               // custom button values
+  // [{ 'list': 'ordered'}, { 'list': 'bullet' }],
+  // [{ 'script': 'sub'}, { 'script': 'super' }],      // superscript/subscript
+  // [{ 'indent': '-1'}, { 'indent': '+1' }],          // outdent/indent
+  // [{ 'direction': 'rtl' }],                         // text direction
+  // [{ 'size': ['small', false, 'large', 'huge'] }],  // custom dropdown
+  // [{ 'header': [1, 2, 3, 4, 5, 6, false] }],
+  // [{ 'color': [] }, { 'background': [] }],          // dropdown with defaults from theme
+  // [{ 'font': [] }],
+  // [{ 'align': [] }],
+  // ['clean']      
+  // [{ 'font': [] }, { 'size': [] }],
+  // [{ 'color': [] }, { 'background': [] }],
+  // [{ 'script': 'super' }, { 'script': 'sub' }],
+  // [ 'direction', { 'align': [] }],
 
-  [{ 'header': 1 }, { 'header': 2 }],               // custom button values
-  [{ 'list': 'ordered'}, { 'list': 'bullet' }],
-  [{ 'script': 'sub'}, { 'script': 'super' }],      // superscript/subscript
-  [{ 'indent': '-1'}, { 'indent': '+1' }],          // outdent/indent
-  [{ 'direction': 'rtl' }],                         // text direction
-
-  [{ 'size': ['small', false, 'large', 'huge'] }],  // custom dropdown
-  [{ 'header': [1, 2, 3, 4, 5, 6, false] }],
-
-  [{ 'color': [] }, { 'background': [] }],          // dropdown with defaults from theme
-  [{ 'font': [] }],
-  [{ 'align': [] }],
-
-  ['clean']      
+  // Setup some default options without link funtionality until it's fixed
+  [{ 'size': [] }],
+  [ 'bold', 'italic', 'underline', 'strike' ],
+  [{ 'header': '1' }, { 'header': '2' }, 'blockquote', 'code-block' ],
+  [{ 'list': 'ordered' }, { 'list': 'bullet'}, { 'indent': '-1' }, { 'indent': '+1' }],
+  // [ 'link', 'image', 'video', 'formula' ],
+  [ 'clean' ]
 ]
 
 $(".rt-textarea").each(function(textarea) {
@@ -28,7 +37,7 @@ $(".rt-textarea").each(function(textarea) {
     theme: 'snow',
     placeholder: "Enter text...",
     modules: {
-      // toolbar: toolbarOptions
+      toolbar: toolbarOptions
     }
   });
   $(this).data("quill", quill)

--- a/lib/challenge_gov/emails.ex
+++ b/lib/challenge_gov/emails.ex
@@ -104,6 +104,7 @@ defmodule ChallengeGov.Emails do
       "You have been invited to the next phase of #{submission_invite.solution.challenge.title}"
     )
     |> assign(:submission_invite, submission_invite)
+    |> assign(:challenge, submission_invite.solution.challenge)
     |> render("submission_invite.html")
   end
 

--- a/lib/web/router.ex
+++ b/lib/web/router.ex
@@ -192,7 +192,7 @@ defmodule Web.Router do
 
     get("/", PageController, :index)
     get("/challenges", PageController, :index, as: :challenge_index)
-    get("/challenge/:id", PageController, :index, as: :challenge_details)
+    get("/challenges#/challenge/:id", PageController, :index, as: :challenge_details)
   end
 
   if Mix.env() == :dev do

--- a/lib/web/templates/email/submission_invite.html.eex
+++ b/lib/web/templates/email/submission_invite.html.eex
@@ -1,3 +1,5 @@
 <div>
   <%= SharedView.render_safe_html(@submission_invite.message) %>
 </div>
+<%= link("Your solutions", to: Routes.solution_path(Endpoint, :index)) %> | 
+<%= link("Challenge details", to: Routes.public_challenge_details_url(Endpoint, :index, @challenge.id)) %>

--- a/test/web/controllers/saved_challenge_controller_test.exs
+++ b/test/web/controllers/saved_challenge_controller_test.exs
@@ -157,7 +157,7 @@ defmodule Web.SavedChallengeControllerTest do
                       "href",
                       61,
                       34,
-                      "http://localhost:4002/public/challenge/#{challenge.id}",
+                      "http://localhost:4002/public/challenges#/challenge/#{challenge.id}",
                       34
                     ]
                   ],


### PR DESCRIPTION
- Add solution link and placeholder challenge details link that points
  to portal rendered challenge details
- Removed link functionality from rich text editor until unsafe: and
  htmlsanitize functionality is fixed when they are rendered