### PR TITLE
Chal 523/docker compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,13 @@ Welcome to the ChallengeGov Data Portal
 
 Install PostgreSQL according to your OS of choice, for MacOS [Postgres.app](https://postgresapp.com/) is recommended.
 
+Alternatively, use the Challenge_gov docker-compose file to run psql locally in a container.
+
+```cd docker
+docker-compose run --service-ports psql
+```
+
+
 To install Elixir, Erlang, and NodeJS it is recommended to use the [asdf version manager](https://asdf-vm.com/#/). Install instructions are copied here for MacOS, for other OSs see [asdf docs](https://asdf-vm.com/#/core-manage-asdf-vm). This also assumes you have [HomeBrew](https://brew.sh/) installed.
 
 ```bash

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,22 @@
+version: "3.4"
+services:
+  psql:
+    build: ./psql/
+    container_name: psql
+    ports:
+      - "5435:5435"
+      - "5432:5432"
+    networks:
+      - server
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+    volumes:
+      - dbdata:/var/lib/postgres
+      - dbdata:/var/lib/postgresql/data
+volumes:
+  dbdata:
+    external: true
+    name: a4e2b5873d8f7ef2344825ad5c0b1b0a98423e173aa549256b69efdc1c648750
+networks:
+  server:

--- a/docker/psql/Dockerfile
+++ b/docker/psql/Dockerfile
@@ -1,0 +1,3 @@
+FROM postgres:12.0
+
+RUN apt-get update


### PR DESCRIPTION
Part of the push to utilize docker compose for simpler local development. DRAFT PR, do not merge yet

- [x] README is up to date
- [x] Docs are up to date with changes (modules and functions)
- [x] Tests are included for changes
- [x] Links in emails use the `_url` route helpers
