### PR TITLE
Chal-79 Public user can print challenge details

### DIFF
--- a/assets/client/src/components/ChallengeDetails.js
+++ b/assets/client/src/components/ChallengeDetails.js
@@ -301,6 +301,9 @@ export const ChallengeDetails = ({challenge, preview, print}) => {
                   <p>{`$${challenge.prize_total.toLocaleString()}`}</p>
                 </div>
               }
+              {challenge.uuid &&
+                <a href={apiUrl + `/public/previews/challenges/${challenge.uuid}?print=true`} target="_blank">print</a>
+              }
             </div>
           </section>
         </section>

--- a/lib/web/views/api/challenge_view.ex
+++ b/lib/web/views/api/challenge_view.ex
@@ -22,6 +22,7 @@ defmodule Web.Api.ChallengeView do
   def render("card.json", %{challenge: challenge}) do
     %{
       id: challenge.id,
+      uuid: challenge.uuid,
       title: challenge.title,
       tagline: challenge.tagline,
       custom_url: challenge.custom_url,
@@ -144,6 +145,7 @@ defmodule Web.Api.ChallengeView do
       terms_and_conditions: HtmlSanitizeEx.basic_html(challenge.terms_and_conditions),
       title: challenge.title,
       types: challenge.types,
+      uuid: challenge.uuid,
       winner_information: challenge.winner_information,
       winner_image: ChallengeView.winner_img_url(challenge),
       gov_delivery_topic_subscribe_link: GovDelivery.public_subscribe_link(challenge),

--- a/test/web/controllers/api/challenge_controller_test.exs
+++ b/test/web/controllers/api/challenge_controller_test.exs
@@ -272,6 +272,7 @@ defmodule Web.Api.ChallengeControllerTest do
     %{
       "description" => challenge.description,
       "id" => challenge.id,
+      "uuid" => challenge.uuid,
       "title" => challenge.title,
       "legal_authority" => "Test legal authority",
       "phase_dates" => nil,


### PR DESCRIPTION
api/challenge_controller.ex
* add uuid to json

ChallengeDetails.js
* add print button to view

- [ ] README is up to date
- [ ] Docs are up to date with changes (modules and functions)
- [ ] Tests are included for changes
- [ ] Links in emails use the `_url` route helpers
