### PR TITLE
Bugfix: add default: 0 to prize_total

### DIFF
--- a/lib/challenge_gov/challenges/challenge.ex
+++ b/lib/challenge_gov/challenges/challenge.ex
@@ -85,7 +85,7 @@ defmodule ChallengeGov.Challenges.Challenge do
     field(:phase_dates, :string)
     field(:judging_criteria, :string)
     field(:prize_type, :string)
-    field(:prize_total, :integer)
+    field(:prize_total, :integer, default: 0)
     field(:non_monetary_prizes, :string)
     field(:prize_description, :string)
     field(:prize_description_delta, :string)

--- a/test/web/controllers/api/challenge_controller_test.exs
+++ b/test/web/controllers/api/challenge_controller_test.exs
@@ -303,7 +303,7 @@ defmodule Web.Api.ChallengeControllerTest do
       "number_of_phases" => nil,
       "winner_image" => nil,
       "tagline" => challenge.tagline,
-      "prize_total" => nil,
+      "prize_total" => 0,
       "brief_description" => challenge.brief_description,
       "phase_descriptions" => nil,
       "federal_partners" => [],


### PR DESCRIPTION
bug: on creating a new challenge, if non-monetary prize only selected
wizard nav buttons won't work
prize_total must be an int to start

- [ ] README is up to date
- [ ] Docs are up to date with changes (modules and functions)
- [ ] Tests are included for changes
- [ ] Links in emails use the `_url` route helpers
