### PR TITLE
Update: allow edits on a published challenges not just published and OPEN

### DIFF
--- a/lib/challenge_gov/challenges/challenge.ex
+++ b/lib/challenge_gov/challenges/challenge.ex
@@ -728,8 +728,8 @@ defmodule ChallengeGov.Challenges.Challenge do
        )
        when not is_nil(date) do
     {:ok, date} = Timex.parse(date, "{ISO:Extended}")
-    {:ok, %{sub_status: sub_status}} = Challenges.get(id)
-    if sub_status === "open", do: struct, else: check_auto_publish_date(struct, date)
+    {:ok, %{status: status}} = Challenges.get(id)
+    if status === "published", do: struct, else: check_auto_publish_date(struct, date)
   end
 
   defp validate_auto_publish_date(struct = %{data: %{auto_publish_date: date}}, params)

--- a/lib/challenge_gov/challenges/challenge.ex
+++ b/lib/challenge_gov/challenges/challenge.ex
@@ -722,19 +722,25 @@ defmodule ChallengeGov.Challenges.Challenge do
   #   end
   # end
 
-  defp validate_auto_publish_date(
-         struct,
-         params = %{"auto_publish_date" => date, "challenge_id" => id}
-       )
+  defp validate_auto_publish_date(struct, %{"auto_publish_date" => date, "challenge_id" => id})
        when not is_nil(date) do
     {:ok, date} = Timex.parse(date, "{ISO:Extended}")
     {:ok, %{status: status}} = Challenges.get(id)
     if status === "published", do: struct, else: check_auto_publish_date(struct, date)
   end
 
-  defp validate_auto_publish_date(struct = %{data: %{auto_publish_date: date}}, params)
+  defp validate_auto_publish_date(
+         struct = %{data: %{auto_publish_date: date, status: status}},
+         _params
+       )
        when not is_nil(date) do
-    check_auto_publish_date(struct, date)
+    case status do
+      "published" ->
+        struct
+
+      _ ->
+        check_auto_publish_date(struct, date)
+    end
   end
 
   defp validate_auto_publish_date(struct, _params) do

--- a/test/challenge_gov/challenges/challenge_details_test.exs
+++ b/test/challenge_gov/challenges/challenge_details_test.exs
@@ -143,7 +143,14 @@ defmodule ChallengeGov.ChallengeDetailsTest do
       {:ok, challenge} =
         Challenges.update(
           challenge,
-          %{"status" => "published", "start_date" => TestHelpers.iso_timestamp(days: -5)},
+          %{
+            "action" => "next",
+            "challenge" => %{
+              "section" => "details",
+              "status" => "published",
+              "auto_publish_date" => TestHelpers.iso_timestamp(days: -5)
+            }
+          },
           user,
           ""
         )

--- a/test/challenge_gov/challenges/challenge_details_test.exs
+++ b/test/challenge_gov/challenges/challenge_details_test.exs
@@ -134,4 +134,37 @@ defmodule ChallengeGov.ChallengeDetailsTest do
       assert updated_challenge.sub_status === nil
     end
   end
+
+  describe "updating a published challenge" do
+    test "success - with auto publish date in the past" do
+      user = AccountHelpers.create_user()
+      challenge = ChallengeHelpers.create_single_phase_challenge(user, %{user_id: user.id})
+
+      {:ok, challenge} =
+        Challenges.update(
+          challenge,
+          %{"status" => "published", "start_date" => TestHelpers.iso_timestamp(days: -5)},
+          user,
+          ""
+        )
+
+      assert challenge.status === "published"
+
+      {:ok, updated_challenge} =
+        Challenges.update(
+          challenge,
+          %{
+            "action" => "next",
+            "challenge" => %{
+              "section" => "details",
+              "brief_description" => "Updated brief description"
+            }
+          },
+          user,
+          ""
+        )
+
+      assert updated_challenge.brief_description === "Updated brief description"
+    end
+  end
 end


### PR DESCRIPTION
Update for [commit fa30060](https://github.com/GSA/Challenge_gov/pull/201/commits/fa300601f49c8d8060f7cb3d717696302a0c5974)

- [x] README is up to date
- [x] Docs are up to date with changes (modules and functions)
- [x] Tests are included for changes
- [x] Links in emails use the `_url` route helpers
