### PR TITLE
Chal 550/wysiwyg: linking and char limited version

### DIFF
--- a/assets/css/app/_base.scss
+++ b/assets/css/app/_base.scss
@@ -450,3 +450,21 @@ label {
 .submission-invites__message .form-group {
   background-color: #fff;
 }
+
+/* Quill link error handling */
+.ql-tooltip.is-invalid {
+  border: 2px solid var(--danger);
+  background-color: #fff !important;
+  z-index: 1 !important;
+  left: 0;
+}
+
+.ql-tooltip span {
+  display: block;
+  font-size: 12px;
+  font-style: italic;
+}
+
+.ql-tooltip {
+  left: 0 !important;
+}

--- a/assets/js/app/_rich_text_editor.js
+++ b/assets/js/app/_rich_text_editor.js
@@ -22,12 +22,12 @@ let toolbarOptions = [
   // [{ 'script': 'super' }, { 'script': 'sub' }],
   // [ 'direction', { 'align': [] }],
 
-  // Setup some default options without link funtionality until it's fixed
+  // Setup some default options
   [{ 'size': [] }],
   [ 'bold', 'italic', 'underline', 'strike' ],
   [{ 'header': '1' }, { 'header': '2' }, 'blockquote', 'code-block' ],
   [{ 'list': 'ordered' }, { 'list': 'bullet'}, { 'indent': '-1' }, { 'indent': '+1' }],
-  // [ 'link', 'image', 'video', 'formula' ],
+  [ 'link', 'image', 'video', 'formula' ],
   [ 'clean' ]
 ]
 
@@ -41,6 +41,35 @@ $(".rt-textarea").each(function(textarea) {
     }
   });
   $(this).data("quill", quill)
+
+  let toolBar = quill.getModule("toolbar")
+  var tooltipSave = quill.theme.tooltip.save;
+  var tooltipShow = quill.theme.tooltip.show;
+
+  quill.theme.tooltip.show = function() {
+    $(this.root).removeClass('is-invalid');
+    $("span").remove('.text-danger')
+    $("span").remove('.text-secondary')
+    tooltipShow.call(this);
+  }
+
+  quill.theme.tooltip.save = function() {
+    var url = this.textbox.value;
+    $(this.root).removeClass('is-invalid');
+    $("span").remove('.text-danger')
+    $("span").remove('.text-secondary')
+
+    let httpRegex = /^https?:\/\//i
+    if(httpRegex.test(url)) {
+      $(this.root).removeClass('is-invalid');
+      tooltipSave.call(this);
+    }
+    else {
+      $(this.root).addClass('is-invalid');
+      $(this.root).append('<span class="text-danger">links must contain "https"</span>')
+      $(this.root).append('<span class="text-secondary">tip: copy and paste url</span>')
+    }
+  };
 
   let fieldName = $(this).data("input")
   let richTextInput = $(`#${fieldName}`)

--- a/assets/js/app/_rich_text_editor.js
+++ b/assets/js/app/_rich_text_editor.js
@@ -46,6 +46,7 @@ $(".rt-textarea").each(function(textarea) {
   var tooltipSave = quill.theme.tooltip.save;
   var tooltipShow = quill.theme.tooltip.show;
 
+  // make sure the tooltip has no remaining errors in new instance
   quill.theme.tooltip.show = function() {
     $(this.root).removeClass('is-invalid');
     $("span").remove('.text-danger')
@@ -53,8 +54,10 @@ $(".rt-textarea").each(function(textarea) {
     tooltipShow.call(this);
   }
 
+  // show errors on save when missing https
   quill.theme.tooltip.save = function() {
     var url = this.textbox.value;
+    // clean out any previous errors
     $(this.root).removeClass('is-invalid');
     $("span").remove('.text-danger')
     $("span").remove('.text-secondary')
@@ -96,3 +99,31 @@ $(".rt-textarea").each(function(textarea) {
     richTextInput.val("")
   }
 })
+
+  // set char limit text
+  const charLimitedField = $(".char-limited-editor")
+  const charLimitedQuill = $(".char-limited-editor .rt-textarea").data("quill")
+
+  if (charLimitedField.length >= 1) {
+    const charLimit = charLimitedQuill.container.attributes["data-limit"].value
+    const charsRemaining = document.getElementById("chars-remaining")
+    const charsLimitText = document.getElementById("char-limit-text")
+
+    // set inital limit
+    charsRemaining.textContent = charLimit
+    charsLimitText.textContent = " characters remaining"
+
+    charLimitedQuill.on('text-change', function() {
+      let remaining = charLimit - (charLimitedQuill.getLength() - 1)
+      if (Math.sign(remaining) != -1) {
+        charsRemaining.textContent = remaining
+        charsLimitText.textContent = " characters remaining"
+      } else {
+        // validation?
+        charsRemaining.style.color = "red"
+        charsLimitText.style.color = "red"
+        charsRemaining.textContent = `${remaining*-1}`
+        charsLimitText.textContent = " characters over the limit"
+      }
+    });
+  }

--- a/assets/js/app/_rich_text_editor.js
+++ b/assets/js/app/_rich_text_editor.js
@@ -98,32 +98,43 @@ $(".rt-textarea").each(function(textarea) {
     deltaInput.val("")
     richTextInput.val("")
   }
-})
 
-  // set char limit text
-  const charLimitedField = $(".char-limited-editor")
-  const charLimitedQuill = $(".char-limited-editor .rt-textarea").data("quill")
+  const setCharLimitHelperText = (charsRemaining, displayNumber, displayText) => {
+    if (Math.sign(charsRemaining) != -1) {
+      displayNumber.css("color", "inherit")
+      displayText.css("color", "inherit")
+      displayNumber.text(charsRemaining)
+      displayText.text(" characters remaining")
+    } else {
+      displayNumber.css("color", "red")
+      displayText.css("color", "red")
+      displayNumber.text(`${charsRemaining * -1}`)
+      displayText.text(" characters over the limit")
+    }
+  }
 
-  if (charLimitedField.length >= 1) {
-    const charLimit = charLimitedQuill.container.attributes["data-limit"].value
-    const charsRemaining = document.getElementById("chars-remaining")
-    const charsLimitText = document.getElementById("char-limit-text")
+  if ($(this).hasClass("rt_char-limited")) {
+    const charLimit = $(this).data("limit")
+    const lengthInput = $(`#${fieldName}_length`)
+    const charsRemaining = $(`#${fieldName}_chars-remaining`)
+    const charLimitText = $(`#${fieldName}_char-limit-text`)
+    let initialCharsRemaining = charLimit - (quill.getLength() - 1)
 
-    // set inital limit
-    charsRemaining.textContent = charLimit
-    charsLimitText.textContent = " characters remaining"
+    // set inital values
+    lengthInput.val(quill.getLength() - 1)
+    if ((quill.getLength() - 1) === 0) {
+      charsRemaining.css("color", "inherit")
+      charLimitText.css("color", "inherit")
+      charsRemaining.text(charLimit)
+      charLimitText.text(" characters remaining")
+    } else {
+      setCharLimitHelperText(initialCharsRemaining, charsRemaining, charLimitText)
+    }
 
-    charLimitedQuill.on('text-change', function() {
-      let remaining = charLimit - (charLimitedQuill.getLength() - 1)
-      if (Math.sign(remaining) != -1) {
-        charsRemaining.textContent = remaining
-        charsLimitText.textContent = " characters remaining"
-      } else {
-        // validation?
-        charsRemaining.style.color = "red"
-        charsLimitText.style.color = "red"
-        charsRemaining.textContent = `${remaining*-1}`
-        charsLimitText.textContent = " characters over the limit"
-      }
+    quill.on('text-change', function() {
+      let numCharsRemaining = charLimit - (quill.getLength() - 1)
+      lengthInput.val(quill.getLength() - 1)
+      setCharLimitHelperText(numCharsRemaining, charsRemaining, charLimitText)
     });
   }
+})

--- a/assets/js/app/_rich_text_editor.js
+++ b/assets/js/app/_rich_text_editor.js
@@ -27,7 +27,7 @@ let toolbarOptions = [
   [ 'bold', 'italic', 'underline', 'strike' ],
   [{ 'header': '1' }, { 'header': '2' }, 'blockquote', 'code-block' ],
   [{ 'list': 'ordered' }, { 'list': 'bullet'}, { 'indent': '-1' }, { 'indent': '+1' }],
-  [ 'link', 'image', 'video', 'formula' ],
+  [ 'link'], // ['image', 'video', 'formula' ],
   [ 'clean' ]
 ]
 

--- a/lib/challenge_gov/challenges/challenge.ex
+++ b/lib/challenge_gov/challenges/challenge.ex
@@ -74,6 +74,8 @@ defmodule ChallengeGov.Challenges.Challenge do
     field(:description, :string)
     field(:description_delta, :string)
     field(:brief_description, :string)
+    field(:brief_description_delta, :string)
+    field(:brief_description_length, :integer, virtual: true)
     field(:how_to_enter, :string)
     field(:fiscal_year, :string)
     field(:start_date, :utc_datetime)
@@ -281,6 +283,8 @@ defmodule ChallengeGov.Challenges.Challenge do
       :description,
       :description_delta,
       :brief_description,
+      :brief_description_delta,
+      :brief_description_length,
       :how_to_enter,
       :fiscal_year,
       :start_date,
@@ -450,7 +454,7 @@ defmodule ChallengeGov.Challenges.Challenge do
     ])
     |> validate_length(:title, max: 90)
     |> validate_length(:tagline, max: 90)
-    |> validate_length(:brief_description, max: 200)
+    |> validate_rich_text_length(:brief_description_length, 200)
     |> validate_length(:description, max: 4000)
     |> validate_length(:other_type, max: 45)
     |> validate_inclusion(:primary_type, @challenge_types)
@@ -459,6 +463,22 @@ defmodule ChallengeGov.Challenges.Challenge do
     |> validate_auto_publish_date(params)
     |> validate_custom_url(params)
     |> validate_phases(params)
+  end
+
+  def validate_rich_text_length(struct, field, length) do
+    value = get_field(struct, field)
+
+    case value do
+      nil ->
+        struct
+
+      _ ->
+        if value > length do
+          add_error(struct, :brief_description, "can't be greater than #{length} characters")
+        else
+          struct
+        end
+    end
   end
 
   def timeline_changeset(struct, params) do

--- a/lib/challenge_gov/challenges/challenge.ex
+++ b/lib/challenge_gov/challenges/challenge.ex
@@ -454,7 +454,7 @@ defmodule ChallengeGov.Challenges.Challenge do
     ])
     |> validate_length(:title, max: 90)
     |> validate_length(:tagline, max: 90)
-    |> validate_rich_text_length(:brief_description_length, 200)
+    |> validate_rich_text_length(:brief_description, 200)
     |> validate_length(:description, max: 4000)
     |> validate_length(:other_type, max: 45)
     |> validate_inclusion(:primary_type, @challenge_types)
@@ -466,7 +466,8 @@ defmodule ChallengeGov.Challenges.Challenge do
   end
 
   def validate_rich_text_length(struct, field, length) do
-    value = get_field(struct, field)
+    field_length = String.to_existing_atom("#{field}_length")
+    value = get_field(struct, field_length)
 
     case value do
       nil ->
@@ -474,7 +475,7 @@ defmodule ChallengeGov.Challenges.Challenge do
 
       _ ->
         if value > length do
-          add_error(struct, :brief_description, "can't be greater than #{length} characters")
+          add_error(struct, field, "can't be greater than #{length} characters")
         else
           struct
         end

--- a/lib/web/templates/challenge/review/_details.html.eex
+++ b/lib/web/templates/challenge/review/_details.html.eex
@@ -32,7 +32,7 @@
 <br/>
 <div>
   <div class="text-bold">Brief description:</div>
-  <div><%= @challenge.brief_description %></div>
+  <div><%= SharedView.render_safe_html(@challenge.brief_description) %></div>
 </div>
 <br/>
 <div>

--- a/lib/web/templates/challenge/wizard/_details.html.eex
+++ b/lib/web/templates/challenge/wizard/_details.html.eex
@@ -59,7 +59,7 @@
 
 <hr/>
 
-<div class="col char-limited-editor">
+<div class="col">
   <label for="brief_description">Short description <span class="required">*</span></label>
   <%= FormView.rt_textarea_field(@form, :brief_description, limit: 200) %>
 </div>

--- a/lib/web/templates/challenge/wizard/_details.html.eex
+++ b/lib/web/templates/challenge/wizard/_details.html.eex
@@ -59,7 +59,10 @@
 
 <hr/>
 
-<%= FormView.textarea_field(@form, :brief_description, label: "Short description (help text: Appears in challenge details header)", limit: 200, required: true) %>
+<div class="col char-limited-editor">
+  <label for="brief_description">Short description <span class="required">*</span></label>
+  <%= FormView.rt_textarea_field(@form, :brief_description, limit: 200) %>
+</div>
 
 <div class="col">
   <label><%= "Long description" %> <span class="required">*</span></label>

--- a/lib/web/views/form_view.ex
+++ b/lib/web/views/form_view.ex
@@ -259,25 +259,39 @@ defmodule Web.FormView do
   def rt_textarea_field(form, field, opts \\ []) do
     opts = Keyword.merge([class: form_group_classes(form, field)], opts)
 
-    char_limited_label =
+    char_limited_tags =
       if opts[:limit] do
         [
-          content_tag(:span, "", id: "chars-remaining", class: "char-limit-label ml-1"),
-          content_tag(:span, "", id: "char-limit-text", class: "char-limit-label ml-1")
+          content_tag(:span, "",
+            id: "challenge_#{Atom.to_string(field)}_chars-remaining",
+            class: "char-limit-label ml-1"
+          ),
+          content_tag(:span, "",
+            id: "challenge_#{Atom.to_string(field)}_char-limit-text",
+            class: "char-limit-label ml-1"
+          ),
+          hidden_input(form, String.to_existing_atom(Atom.to_string(field) <> "_length"))
         ]
       else
         ""
       end
 
+    classes =
+      if opts[:limit] do
+        "rt-textarea rt_char-limited"
+      else
+        "rt-textarea"
+      end
+
     content_tag(:div, opts) do
       [
         content_tag(:div, "",
-          class: "rt-textarea",
+          class: classes,
           data: [input: form.id <> "_" <> Atom.to_string(field), limit: opts[:limit]]
         ),
-        char_limited_label,
+        char_limited_tags,
         hidden_input(form, field, class: form_control_classes(form, field)),
-        hidden_input(form, String.to_atom(Atom.to_string(field) <> "_delta")),
+        hidden_input(form, String.to_existing_atom(Atom.to_string(field) <> "_delta")),
         error_tag(form, field)
       ]
     end

--- a/lib/web/views/form_view.ex
+++ b/lib/web/views/form_view.ex
@@ -259,14 +259,25 @@ defmodule Web.FormView do
   def rt_textarea_field(form, field, opts \\ []) do
     opts = Keyword.merge([class: form_group_classes(form, field)], opts)
 
+    char_limited_label =
+      if opts[:limit] do
+        [
+          content_tag(:span, "", id: "chars-remaining", class: "char-limit-label ml-1"),
+          content_tag(:span, "", id: "char-limit-text", class: "char-limit-label ml-1")
+        ]
+      else
+        ""
+      end
+
     content_tag(:div, opts) do
       [
         content_tag(:div, "",
           class: "rt-textarea",
-          data: [input: form.id <> "_" <> Atom.to_string(field)]
+          data: [input: form.id <> "_" <> Atom.to_string(field), limit: opts[:limit]]
         ),
+        char_limited_label,
         hidden_input(form, field, class: form_control_classes(form, field)),
-        hidden_input(form, String.to_existing_atom(Atom.to_string(field) <> "_delta")),
+        hidden_input(form, String.to_atom(Atom.to_string(field) <> "_delta")),
         error_tag(form, field)
       ]
     end

--- a/priv/repo/migrations/20210422044336_add_brief_description_delta_to_challenges.exs
+++ b/priv/repo/migrations/20210422044336_add_brief_description_delta_to_challenges.exs
@@ -1,0 +1,9 @@
+defmodule ChallengeGov.Repo.Migrations.AddBriefDescriptionDeltaToChallenges do
+  use Ecto.Migration
+
+  def change do
+    alter table(:challenges) do
+      add :brief_description_delta, :text
+    end
+  end
+end


### PR DESCRIPTION
Add back links to quill rich text editor and provide error handling for erroneous links (without https)

<img width="455" alt="Screen Shot 2021-04-20 at 4 16 06 PM" src="https://user-images.githubusercontent.com/13442896/115617613-978d3880-a2bf-11eb-859d-f780d53438ef.png">

Create char limited quill rich text editor for brief desc field


- [ ] README is up to date
- [ ] Docs are up to date with changes (modules and functions)
- [ ] Tests are included for changes
- [ ] Links in emails use the `_url` route helpers
