### PR TITLE
CHAL-549 Print view updates and automatic dialog box

### DIFF
--- a/assets/client/src/components/ChallengeDetails.js
+++ b/assets/client/src/components/ChallengeDetails.js
@@ -58,9 +58,9 @@ export const ChallengeDetails = ({challenge, preview, print}) => {
 
   const renderFollowButton = (challenge) => {
     if (challenge.subscriber_count > 0) {
-      return <button className="follow-btn" id="followChallengeButton"><i className="far fa-bookmark mr-3"></i>Follow challenge ({ challenge.subscriber_count })</button>
+      return <span className="follow-btn" id="followChallengeButton"><i className="far fa-bookmark mr-3"></i>Follow challenge ({ challenge.subscriber_count })</span>
     } else {
-      return <button className="follow-btn" id="followChallengeButton"><i className="far fa-bookmark mr-3"></i>Follow challenge</button>
+      return <span className="follow-btn" id="followChallengeButton"><i className="far fa-bookmark mr-3"></i>Follow challenge</span>
     }
   }
 
@@ -235,6 +235,25 @@ export const ChallengeDetails = ({challenge, preview, print}) => {
     }
   }
 
+  const renderInteractiveItems = () => {
+    if (print != "true") {
+      return (
+        <>
+          {renderApplyButton(challenge)}
+          <div className="detail-section__follow">
+            {renderFollowButton(challenge)}
+            {renderFollowTooltip()}
+            {challenge.uuid &&
+              <a className="follow-btn" href={apiUrl + `/public/previews/challenges/${challenge.uuid}?print=true`} target="_blank">
+                <span className="follow-btn"><i className="fas fa-print mr-3"></i>Print challenge</span>
+              </a>
+            }
+          </div>
+        </>
+      )
+    }
+  }
+
   return (
     challenge ? (
       <div className="w-100">
@@ -278,11 +297,7 @@ export const ChallengeDetails = ({challenge, preview, print}) => {
               </div>
             </div>
             <div className="detail-section">
-              {renderApplyButton(challenge)}
-              <div className="detail-section__follow">
-                {renderFollowButton(challenge)}
-                {renderFollowTooltip()}
-              </div>
+              {renderInteractiveItems()}
               <div className="item">
                 <p className="info-title">Submission period:</p>
                 {submissionPeriod(challenge.phases)}
@@ -301,26 +316,23 @@ export const ChallengeDetails = ({challenge, preview, print}) => {
                   <p>{`$${challenge.prize_total.toLocaleString()}`}</p>
                 </div>
               }
-              {challenge.uuid &&
-                <a href={apiUrl + `/public/previews/challenges/${challenge.uuid}?print=true`} target="_blank">print</a>
-              }
             </div>
           </section>
         </section>
         <ChallengeTabs print={print}>
           <div label="Overview">
-            <Overview challenge={challenge} />
+            <Overview challenge={challenge} print={print} />
           </div>
           { challenge.events.length > 0 &&
             <div label="Timeline">
-              <Timeline challenge={challenge} />
+              <Timeline challenge={challenge} print={print} />
             </div> 
           }
           <div label="Prizes">
-            <Prizes challenge={challenge} />
+            <Prizes challenge={challenge} print={print} />
           </div>
           <div label="Rules">
-            <Rules challenge={challenge} />
+            <Rules challenge={challenge} print={print} />
           </div>
           <div label="Judging">
             <Judging challenge={challenge} print={print} />
@@ -335,14 +347,14 @@ export const ChallengeDetails = ({challenge, preview, print}) => {
           }
           { (challenge.faq || documentsForSection(challenge, "faq") > 0) &&
             <div label="FAQ">
-              <FAQ challenge={challenge} />
+              <FAQ challenge={challenge} print={print} />
             </div>
           }
           <div label="Contact">
             <ContactForm preview={preview} />
           </div>
           <div label="Winners" disabled={!challenge.winner_information} >
-            <Winners challenge={challenge} />
+            <Winners challenge={challenge} print={print} />
           </div>
         </ChallengeTabs>
       </div>

--- a/assets/client/src/components/ChallengeTab.js
+++ b/assets/client/src/components/ChallengeTab.js
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react'
 import { Tooltip } from 'reactstrap'
 import { SectionResources } from "./challenge_tabs/SectionResources"
 
-export const ChallengeTab = ({label, downloadsLabel, section, challenge, wrapContent = true, children}) => {
+export const ChallengeTab = ({label, downloadsLabel, section, challenge, print, wrapContent = true, children}) => {
   const [copyTooltipOpen, setCopyTooltipOpen] = useState(false)
 
   useEffect(() => {
@@ -28,14 +28,16 @@ export const ChallengeTab = ({label, downloadsLabel, section, challenge, wrapCon
     <section className="challenge-tab container">
       <div className="challenge-tab__header">
         <span>{label}</span>
-        <div className="float-right">
-          <input id="challenge-link-text" className="opacity-0" defaultValue={window.location.href}/>
-          <button id="challenge-link-btn" className="usa-button usa-button--unstyled text-decoration-none" onClick={handleCopyLink}>
-            <i className="far fa-copy mr-1"></i>
-            <span>Copy share link</span>
-          </button>
-          <Tooltip isOpen={copyTooltipOpen} fade={true} target="challenge-link-btn">Link copied</Tooltip>
-        </div>
+        {!print &&
+          <div className="float-right">
+            <input id="challenge-link-text" className="opacity-0" defaultValue={window.location.href}/>
+            <button id="challenge-link-btn" className="usa-button usa-button--unstyled text-decoration-none" onClick={handleCopyLink}>
+              <i className="far fa-copy mr-1"></i>
+              <span>Copy share link</span>
+            </button>
+            <Tooltip isOpen={copyTooltipOpen} fade={true} target="challenge-link-btn">Link copied</Tooltip>
+          </div>
+        }
       </div>
       <hr/>
       <section className="card challenge-tab__content">

--- a/assets/client/src/components/PreviewBanner.js
+++ b/assets/client/src/components/PreviewBanner.js
@@ -1,16 +1,8 @@
 import React from 'react'
 import moment from 'moment'
 
-export const PreviewBanner = ({challenge, print}) => {
-  const renderPrintViewToggle = () => {
-    const location = window.location.href.split('?')[0]
-
-    if (print) {
-      return <a href={location}>Switch to preview view</a>
-    } else {
-      return <a href={location + "?print=true"}>Switch to printable view</a>
-    }
-  }
+export const PreviewBanner = ({challenge}) => {
+  const location = window.location.href.split('?')[0]
 
   return (
     challenge ? (
@@ -28,7 +20,7 @@ export const PreviewBanner = ({challenge, print}) => {
             <div>
               <span className="mr-3">Preview generated on {moment().format("llll")}</span>
               <a className="mr-3" href={window.location.href}>Refresh page</a>
-              {renderPrintViewToggle()}
+              <a href={location + "?print=true"}>Print</a>
             </div> 
             <br/>
             <div>Link to share for internal agency review:</div>

--- a/assets/client/src/components/challenge_tabs/FAQ.js
+++ b/assets/client/src/components/challenge_tabs/FAQ.js
@@ -1,9 +1,9 @@
 import React from 'react'
 import { ChallengeTab } from "../ChallengeTab"
 
-export const FAQ = ({challenge}) => {
+export const FAQ = ({challenge, print}) => {
   return (
-    <ChallengeTab label="Frequently asked questions" downloadsLabel="Additional FAQ documents" section="faq" challenge={challenge}>
+    <ChallengeTab label="Frequently asked questions" downloadsLabel="Additional FAQ documents" section="faq" challenge={challenge} print={print}>
       <div dangerouslySetInnerHTML={{ __html: challenge.faq }}></div>
     </ChallengeTab>
   )

--- a/assets/client/src/components/challenge_tabs/HowToEnter.js
+++ b/assets/client/src/components/challenge_tabs/HowToEnter.js
@@ -31,7 +31,7 @@ export const HowToEnter = ({challenge, print}) => {
   }
 
   return (
-    <ChallengeTab label="How to enter" downloadsLabel="Additional documents on how to enter" section="how_to_enter" challenge={challenge} wrapContent={isSinglePhase(challenge)}>
+    <ChallengeTab label="How to enter" downloadsLabel="Additional documents on how to enter" section="how_to_enter" challenge={challenge} wrapContent={isSinglePhase(challenge)} print={print}>
       {renderPhaseData(challenge.phases)}
     </ChallengeTab>
   )

--- a/assets/client/src/components/challenge_tabs/Judging.js
+++ b/assets/client/src/components/challenge_tabs/Judging.js
@@ -31,7 +31,7 @@ export const Judging = ({challenge, print}) => {
   }
 
   return (
-    <ChallengeTab label="Judging" downloadsLabel="Additional judging documents" section="judging" challenge={challenge} wrapContent={isSinglePhase(challenge)}>
+    <ChallengeTab label="Judging" downloadsLabel="Additional judging documents" section="judging" challenge={challenge} wrapContent={isSinglePhase(challenge)} print={print}>
       {renderPhaseData(challenge.phases)}
     </ChallengeTab>
   )

--- a/assets/client/src/components/challenge_tabs/Overview.js
+++ b/assets/client/src/components/challenge_tabs/Overview.js
@@ -1,9 +1,9 @@
 import React from 'react'
 import { ChallengeTab } from "../ChallengeTab"
 
-export const Overview = ({challenge}) => {
+export const Overview = ({challenge, print}) => {
   return (
-    <ChallengeTab label="Overview" downloadsLabel="Additional overview documents" section="general" challenge={challenge}>
+    <ChallengeTab label="Overview" downloadsLabel="Additional overview documents" section="general" challenge={challenge} print={print}>
       <div dangerouslySetInnerHTML={{ __html: challenge.description }}></div>
     </ChallengeTab>
   )

--- a/assets/client/src/components/challenge_tabs/Prizes.js
+++ b/assets/client/src/components/challenge_tabs/Prizes.js
@@ -1,9 +1,9 @@
 import React from 'react'
 import { ChallengeTab } from "../ChallengeTab"
 
-export const Prizes = ({challenge}) => {
+export const Prizes = ({challenge, print}) => {
   return (
-    <ChallengeTab label="Prizes" downloadsLabel="Additional prize documents" section="prizes" challenge={challenge}>
+    <ChallengeTab label="Prizes" downloadsLabel="Additional prize documents" section="prizes" challenge={challenge} print={print}>
       <div>{challenge.prize_total}</div>
       <div>{challenge.non_monetary_prizes}</div>
       <div dangerouslySetInnerHTML={{ __html: challenge.prize_description }}></div>

--- a/assets/client/src/components/challenge_tabs/Rules.js
+++ b/assets/client/src/components/challenge_tabs/Rules.js
@@ -1,9 +1,9 @@
 import React from 'react'
 import { ChallengeTab } from "../ChallengeTab"
 
-export const Rules = ({challenge}) => {
+export const Rules = ({challenge, print}) => {
   return (
-    <ChallengeTab label="Rules" downloadsLabel="Additional rule documents" section="rules" challenge={challenge}>
+    <ChallengeTab label="Rules" downloadsLabel="Additional rule documents" section="rules" challenge={challenge} print={print}>
       <div dangerouslySetInnerHTML={{ __html: challenge.rules }}></div>
     </ChallengeTab>
   )

--- a/assets/client/src/components/challenge_tabs/Timeline.js
+++ b/assets/client/src/components/challenge_tabs/Timeline.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { ChallengeTab } from "../ChallengeTab"
 
-export const Timeline = ({challenge}) => {
+export const Timeline = ({challenge, print}) => {
   const renderEvents = (events) => {
     return (
       events.map((event, index) => {
@@ -17,7 +17,7 @@ export const Timeline = ({challenge}) => {
   }
 
   return (
-    <ChallengeTab label="Timeline" downloadsLabel="Additional timeline documents" section="timeline" challenge={challenge}>
+    <ChallengeTab label="Timeline" downloadsLabel="Additional timeline documents" section="timeline" challenge={challenge} print={print}>
       {renderEvents(challenge.events)}
     </ChallengeTab>
   )

--- a/assets/client/src/components/challenge_tabs/Winners.js
+++ b/assets/client/src/components/challenge_tabs/Winners.js
@@ -1,9 +1,9 @@
 import React from 'react'
 import { ChallengeTab } from "../ChallengeTab"
 
-export const Winners = ({challenge}) => {
+export const Winners = ({challenge, print}) => {
   return (
-    <ChallengeTab label="Winners" downloadsLabel="Additional winner documents" section="winners" challenge={challenge}>
+    <ChallengeTab label="Winners" downloadsLabel="Additional winner documents" section="winners" challenge={challenge} print={print}>
       <div>{challenge.winner_image}</div>
       <div>{challenge.winner_information}</div>
     </ChallengeTab>

--- a/assets/client/src/pages/PreviewPage.js
+++ b/assets/client/src/pages/PreviewPage.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useState, useRef } from 'react'
 import axios from 'axios'
 import queryString from 'query-string'
 import { useParams, useLocation } from "react-router-dom";
@@ -8,7 +8,9 @@ import { PreviewBanner } from '../components/PreviewBanner';
 
 export const PreviewPage = () => {
   const [currentChallenge, setCurrentChallenge] = useState()
-  const [loadingState, setLoadingState] = useState(false)
+  const [loadingState, setLoadingState] = useState(null)
+
+  const isMounted = useRef(false)
 
   let { challengeId } = useParams()
   let query = useLocation().search
@@ -33,19 +35,29 @@ export const PreviewPage = () => {
       })
   }, [])
 
+  const launchPrintDialogue = () => {
+    if (loadingState === false) {
+      setTimeout(() => {
+        window.print()
+      }, 1000);
+    }
+  }
+
   return (
     <div className="challenge-preview py-5">
-      <div className="challenge-preview__top row mb-5">
-        <div className="col-md-4">
-          <ChallengeTile challenge={currentChallenge} preview={true} loading={loadingState}/>
+      {!print &&
+        <div className="challenge-preview__top row mb-5">
+          <div className="col-md-4">
+            <ChallengeTile challenge={currentChallenge} preview={true} loading={loadingState}/>
+          </div>
+          <div className="col-md-8">
+            <PreviewBanner challenge={currentChallenge} />
+          </div>
         </div>
-        <div className="col-md-8">
-          <PreviewBanner challenge={currentChallenge} print={print} />
-        </div>
-      </div>
+      }
       <div className="row">
         <div className="col">
-          <ChallengeDetails challenge={currentChallenge} preview={true} loading={loadingState} print={print} />
+          <ChallengeDetails ref={print && launchPrintDialogue()} challenge={currentChallenge} preview={true} loading={loadingState} print={print} />
         </div>
       </div>
     </div>

--- a/assets/css/public/_details-page.scss
+++ b/assets/css/public/_details-page.scss
@@ -9,7 +9,7 @@
 
   &__content {
     margin: 30px;
-    min-width: 60%;
+    min-width: 75%;
     max-width: 1440px;
     height: 80%;
     border-radius: 10px;
@@ -130,16 +130,15 @@
 
     &__follow {
       // margin-bottom: 1.5rem;
+      height: 100%;
+      width: 100%;
+      display: flex;
+      justify-content: space-around;
 
       .follow-btn {
-        height: 100%;
-        width: 100%;
-        // padding: .5rem;
         align-self: center;
         color: #2d618a;
-        border-radius: 7px;
-        border: 1px solid #2d618a;
-        box-shadow: 0 2px 15px 0 rgba(0,0,0,0.2);
+        cursor: pointer;
       }
     }
 
@@ -283,10 +282,11 @@
       &__follow {
         grid-row: 1 / span 2;
         grid-column: 1;
+        width: 80%;
 
         .follow-btn {
-          width: 80%;
-          padding: 0 40px;
+          // width: 80%;
+          // padding: 0 40px;
         }
       }
 


### PR DESCRIPTION
### Test:

1. Go to: http://localhost:4000/public#/
2. select a challenge
3. tile, banner and copy share link should NOT be visible
4. print dialog box should open up automatically
5. all challenge sections should be visible in dialog preview
6. printing should show same result

---

1. as an Admin, view a challenge: eg http://localhost:4000/challenges/1102
2. click 'print' in 'Other Actions'
3. new tab should open
4. 3-6 of above should be true



### Changes:

_details-page.scss
* make hero min width wider (esp for 1440 screen)
* reconfigure positioning for two buttons

PreviewPage.js
* add ref
* launch print dialog 1s after ref appears
* conditionally display tile and banner dependent on print=true

challenge_tabs/Winners.js, Timeline.js, Rules.js, Prizes.js,
Overview.js, Judging.js, HowToEnter.js, FAQ.js
* add print prop to component and/or ChallengeTab

PreviewBanner.js
* set view button to print only since banner is only on preview page

ChallengeTab.js
* add print prop
* conditionally display 'copy share link' to !print

ChallengeDetails.js
* change follow button from bar to link
* add print button to follow space matching follow link styling
* abstract interactive items: apply, follow, print
* render interactive items only on !print
* add print prop to all section components

### TO DO:

#### Refactor:
* exit print page? 
  * opens in new tab
  * but dialog 'cancel' just puts you on that page
  * different 'back' locations: public view or preview
  * button to switch out of print view? 
* change from conditional rendering to `@media print` classes
* update `@media print` css to prevent section cutoff 
  * `display: block? inline?`, `overflow:visible`
* rename 'follow' CSS (since now includes printing)
* show sections with nothing in them? 
  * OR have placeholder text there? eg winners: 'coming soon'
* remove horizontal sections  (since they're all listed?) (if not, only show ones displayed below)
* show attachments in sections?
* last Design change: replace 'copy share link' with copy/print icons (with hover text!) for printing single section as well
<img width="812" alt="Screen Shot 2021-04-26 at 9 06 06 AM" src="https://user-images.githubusercontent.com/13442896/116105878-bbfe6180-a67f-11eb-82a0-6ab19d5f3541.png">

- [ ] README is up to date
- [ ] Docs are up to date with changes (modules and functions)
- [ ] Tests are included for changes
- [ ] Links in emails use the `_url` route helpers
