### PR TITLE
Added fetch and auth plugs for challenges

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,3 +2,4 @@
 - [ ] Docs are up to date with changes (modules and functions)
 - [ ] Tests are included for changes
 - [ ] Links in emails use the `_url` route helpers
+- [ ] Controllers modified contain appropriate authorization plugs

--- a/lib/challenge_gov/challenges.ex
+++ b/lib/challenge_gov/challenges.ex
@@ -478,6 +478,7 @@ defmodule ChallengeGov.Challenges do
       :non_federal_partners,
       :agency,
       :sub_agency,
+      :challenge_owners,
       :challenge_owner_users,
       :events,
       phases: ^from(p in Phase, order_by: p.start_date),

--- a/lib/challenge_gov/phases.ex
+++ b/lib/challenge_gov/phases.ex
@@ -35,7 +35,7 @@ defmodule ChallengeGov.Phases do
 
   defp base_query(query) do
     query
-    |> preload([:challenge, :solutions])
+    |> preload([:solutions, challenge: [:challenge_owners]])
   end
 
   def is_current?(%{start_date: start_date, end_date: end_date}) do

--- a/lib/web/controllers/api/phase_winner_controller.ex
+++ b/lib/web/controllers/api/phase_winner_controller.ex
@@ -5,8 +5,11 @@ defmodule Web.Api.PhaseWinnerController do
 
   alias ChallengeGov.PhaseWinners
 
-  def upload_overview_image(conn, %{"id" => id, "overview_image" => overview_image}) do
-    {:ok, phase_winner} = PhaseWinners.get(id)
+  plug Web.Plugs.FetchChallenge, id_param: "phase_winner_id"
+  plug Web.Plugs.AuthorizeChallenge
+
+  def upload_overview_image(conn, %{"id" => _id, "overview_image" => overview_image}) do
+    %{current_phase_winner: phase_winner} = conn.assigns
 
     case PhaseWinners.upload_overview_image(phase_winner, overview_image) do
       {:ok, overview_image_path} ->

--- a/lib/web/controllers/api/winner_controller.ex
+++ b/lib/web/controllers/api/winner_controller.ex
@@ -6,6 +6,9 @@ defmodule Web.Api.WinnerController do
   alias ChallengeGov.PhaseWinners
   alias ChallengeGov.Winners
 
+  plug Web.Plugs.FetchChallenge, id_param: "phase_winner_id"
+  plug Web.Plugs.AuthorizeChallenge
+
   def upload_image(conn, %{"id" => id, "image" => image}) do
     {:ok, phase_winner} = PhaseWinners.get(id)
 

--- a/lib/web/plugs/authorize_challenge.ex
+++ b/lib/web/plugs/authorize_challenge.ex
@@ -1,0 +1,42 @@
+defmodule Web.Plugs.AuthorizeChallenge do
+  @moduledoc """
+  Verify the currently logged in user has edit permissions
+  for the current challenge set in the conn assigns
+
+  Requires the following plugs to be called before this one can function:
+  Web.Plugs.FetchUser - Sets current_user in assigns
+  Web.Plugs.FetchChallenge - Sets current_challenge in assigns
+  """
+
+  import Phoenix.Controller
+
+  alias ChallengeGov.Challenges
+  alias Web.Router.Helpers, as: Routes
+
+  def init(default), do: default
+
+  def call(conn, opts) do
+    redirect_route = Keyword.get(opts, :redirect, Routes.dashboard_path(conn, :index))
+    %{current_user: user} = conn.assigns
+
+    case allowed_to_edit?(conn, user) do
+      {:ok, _challenge} ->
+        conn
+
+      {:error, :not_permitted} ->
+        conn
+        |> put_flash(:error, "You are not allowed to view this challenge")
+        |> redirect(to: redirect_route)
+    end
+  end
+
+  defp allowed_to_edit?(conn, user) do
+    case Map.fetch(conn.assigns, :current_challenge) do
+      {:ok, challenge} ->
+        Challenges.allowed_to_edit(user, challenge)
+
+      :error ->
+        {:error, :not_permitted}
+    end
+  end
+end

--- a/lib/web/plugs/fetch_challenge.ex
+++ b/lib/web/plugs/fetch_challenge.ex
@@ -1,0 +1,75 @@
+defmodule Web.Plugs.FetchChallenge do
+  @moduledoc """
+  Fetches a challenge and sets it in the conn when applicable.
+  Able to override id to use if something other than "id" is
+  passed into the controller action's params. Including "phase_id"
+  """
+
+  import Plug.Conn
+
+  alias ChallengeGov.Challenges
+  alias ChallengeGov.Phases
+  alias ChallengeGov.PhaseWinners
+  alias ChallengeGov.Repo
+
+  def init(default), do: default
+
+  def call(conn, opts) do
+    id_param = Keyword.get(opts, :id_param, "id")
+
+    case id_param do
+      "id" ->
+        load_challenge(conn, conn.params["id"])
+
+      "challenge_id" ->
+        load_challenge(conn, conn.params["challenge_id"])
+
+      "phase_id" ->
+        load_challenge_through_phase(conn, conn.params["phase_id"])
+
+      "phase_winner_id" ->
+        load_challenge_through_phase_winner(conn, conn.params["id"])
+    end
+  end
+
+  defp load_challenge(conn, id) do
+    case Challenges.get(id) do
+      {:ok, challenge} ->
+        challenge = Repo.preload(challenge, :challenge_owners)
+
+        assign(conn, :current_challenge, challenge)
+
+      {:error, :not_found} ->
+        conn
+    end
+  end
+
+  defp load_challenge_through_phase(conn, id) do
+    case Phases.get(id) do
+      {:ok, phase} ->
+        phase = Repo.preload(phase, challenge: [:challenge_owners])
+
+        conn
+        |> assign(:current_challenge, phase.challenge)
+        |> assign(:current_phase, phase)
+
+      {:error, :not_found} ->
+        conn
+    end
+  end
+
+  defp load_challenge_through_phase_winner(conn, id) do
+    case PhaseWinners.get(id) do
+      {:ok, phase_winner} ->
+        phase_winner = Repo.preload(phase_winner, phase: [challenge: [:challenge_owners]])
+
+        conn
+        |> assign(:current_challenge, phase_winner.phase.challenge)
+        |> assign(:current_phase, phase_winner.phase)
+        |> assign(:current_phase_winner, phase_winner)
+
+      {:error, :not_found} ->
+        conn
+    end
+  end
+end

--- a/lib/web/views/api/phase_winner_view.ex
+++ b/lib/web/views/api/phase_winner_view.ex
@@ -1,7 +1,9 @@
 defmodule Web.Api.PhaseWinnerView do
   use Web, :view
 
+  alias Stein.Storage
+
   def render("upload_overview_image.json", %{overview_image_path: overview_image_path}) do
-    %{overview_image_path: overview_image_path}
+    %{overview_image_path: Storage.url(overview_image_path)}
   end
 end

--- a/lib/web/views/api/winner_view.ex
+++ b/lib/web/views/api/winner_view.ex
@@ -1,7 +1,9 @@
 defmodule Web.Api.WinnerView do
   use Web, :view
 
+  alias Stein.Storage
+
   def render("upload_image.json", %{image_path: image_path}) do
-    %{image_path: image_path}
+    %{image_path: Storage.url(image_path)}
   end
 end


### PR DESCRIPTION
Adds new fetch and auth plugs to fetch challenges, phases, phase_winners
as needed and set them to the conn. Currently implemented in the phase
winner controllers
