### PR TITLE
Block ability to delete for solvers once phase is closed

### DIFF
--- a/lib/challenge_gov/submissions.ex
+++ b/lib/challenge_gov/submissions.ex
@@ -221,7 +221,7 @@ defmodule ChallengeGov.Submissions do
     if submission.challenge.sub_status === "archived" do
       {:error, :not_permitted}
     else
-      submission_phase_is_open?(submission)
+      submission_phase_is_open(submission)
     end
   end
 
@@ -241,7 +241,7 @@ defmodule ChallengeGov.Submissions do
     end
   end
 
-  def submission_phase_is_open?(submission) do
+  def submission_phase_is_open(submission) do
     phase_close = submission.phase.end_date
     now = Timex.now()
 
@@ -254,12 +254,17 @@ defmodule ChallengeGov.Submissions do
     end
   end
 
-  def allowed_to_delete?(user, submission) do
-    if submission.submitter_id === user.id or
-         (Accounts.has_admin_access?(user) and !is_nil(submission.manager_id)) do
-      {:ok, submission}
-    else
-      {:error, :not_permitted}
+  def allowed_to_delete(%{:id => id}, submission = %{:submitter_id => id}) do
+    submission_phase_is_open(submission)
+  end
+
+  def allowed_to_delete(user, submission) do
+    case Accounts.has_admin_access?(user) and !is_nil(submission.manager_id) do
+      true ->
+        {:ok, submission}
+
+      false ->
+        {:error, :not_permitted}
     end
   end
 

--- a/lib/web/controllers/submission_controller.ex
+++ b/lib/web/controllers/submission_controller.ex
@@ -356,7 +356,7 @@ defmodule Web.SubmissionController do
     %{current_user: user} = conn.assigns
     {:ok, submission} = Submissions.get(id)
 
-    with {:ok, submission} <- Submissions.allowed_to_delete?(user, submission),
+    with {:ok, submission} <- Submissions.allowed_to_delete(user, submission),
          {:ok, submission} <- Submissions.delete(submission) do
       conn
       |> put_flash(:info, "Submission deleted")

--- a/lib/web/views/submission_view.ex
+++ b/lib/web/views/submission_view.ex
@@ -129,7 +129,7 @@ defmodule Web.SubmissionView do
   end
 
   def submission_delete_link(conn, submission, user, opts \\ []) do
-    case Submissions.allowed_to_delete?(user, submission) do
+    case Submissions.allowed_to_delete(user, submission) do
       {:ok, submission} ->
         link(opts[:label] || "Delete",
           to: Routes.submission_path(conn, :delete, submission.id),
@@ -137,6 +137,9 @@ defmodule Web.SubmissionView do
           class: "btn btn-link text-danger",
           data: [confirm: "Are you sure you want to delete this submission?"]
         )
+
+      {:error, :not_permitted} ->
+        nil
     end
   end
 


### PR DESCRIPTION
submissions.ex
* remove ? from name on non-boolean returning fns
* refactor allowed_to_delete to match on user id/submitter id and catch
all fn head

submission_controller.ex
* update changed fn name

submission_view.ex
* add error clause for delete button helper on submission index

- [ ] README is up to date
- [ ] Docs are up to date with changes (modules and functions)
- [ ] Tests are included for changes
- [ ] Links in emails use the `_url` route helpers
- [ ] Controllers modified contain appropriate authorization plugs
