### PR TITLE
Restrict Solver permissions on Challenges

### DIFF
--- a/lib/web/controllers/challenge_controller.ex
+++ b/lib/web/controllers/challenge_controller.ex
@@ -9,7 +9,7 @@ defmodule Web.ChallengeController do
 
   plug(
     Web.Plugs.EnsureRole,
-    [:super_admin, :admin, :challenge_owner] when action not in [:index, :show]
+    [:super_admin, :admin, :challenge_owner]
   )
 
   action_fallback(Web.FallbackController)

--- a/test/web/controllers/challenge_controller_test.exs
+++ b/test/web/controllers/challenge_controller_test.exs
@@ -58,6 +58,18 @@ defmodule Web.ChallengeControllerTest do
       assert conn.halted
       assert redirected_to(conn) == Routes.session_path(conn, :new)
     end
+
+    test "failure: access list of challenges as a solver", %{conn: conn} do
+      conn = prep_conn_solver(conn)
+      %{current_user: user} = conn.assigns
+
+      conn = get(conn, Routes.challenge_path(conn, :index))
+
+      assert conn.status === 302
+      assert get_flash(conn, :error) === "You are not authorized"
+      assert conn.halted
+      assert redirected_to(conn) == Routes.dashboard_path(conn, :index)
+    end
   end
 
   describe "show for challenges" do
@@ -181,6 +193,11 @@ defmodule Web.ChallengeControllerTest do
 
   defp prep_conn(conn) do
     user = AccountHelpers.create_user(%{role: "admin"})
+    assign(conn, :current_user, user)
+  end
+
+  defp prep_conn_solver(conn) do
+    user = AccountHelpers.create_user(%{role: "solver"})
     assign(conn, :current_user, user)
   end
 end


### PR DESCRIPTION
challenge_controller.ex
* remove solver from accessing any Challenge action in ensure user plug

challenge_controller_test.exs
* add test failure solver accessing challenge index

- [ ] README is up to date
- [ ] Docs are up to date with changes (modules and functions)
- [ ] Tests are included for changes
- [ ] Links in emails use the `_url` route helpers
- [ ] Controllers modified contain appropriate authorization plugs
