### PR TITLE
Remove save draft button from submitted submissions

### DIFF
--- a/lib/web/templates/submission/_actions.html.eex
+++ b/lib/web/templates/submission/_actions.html.eex
@@ -1,6 +1,6 @@
 <div class="btn-group btn-group-sm" role="group" aria-label="Button group with nested dropdown">
   <%= link("View", to: Routes.submission_path(@conn, :show, @submission.id), class: "btn btn-default btn-xs mr-2") %>
-  <%= if can_edit?(@user, @submission) do %>
+  <%= if Submissions.is_editable?(@user, @submission) do %>
     <%= link("Edit", to: Routes.submission_path(@conn, :edit, @submission.id), class: "btn btn-default btn-xs mr-2") %>
   <% else %>
     <span class="row-text">closed</span>

--- a/lib/web/templates/submission/_form.html.eex
+++ b/lib/web/templates/submission/_form.html.eex
@@ -76,6 +76,6 @@
 
     <%= cancel_button(@conn, @action, @challenge) %>
     <%= submit("Review and submit", name: "action", value: "review", class: "btn btn-primary float-right") %>
-    <%= save_draft_button() %>
+    <%= save_draft_button(@data) %>
   <% end) %>
 </section>

--- a/lib/web/templates/submission/edit.html.eex
+++ b/lib/web/templates/submission/edit.html.eex
@@ -15,7 +15,7 @@
       <%= SharedView.render_breadcrumbs([
         %{text: "Home", route: Routes.dashboard_path(Web.Endpoint, :index)},
         %{text: "Submissions", route: Routes.submission_path(@conn, :index)},
-        %{text: @submission.title, route: Routes.submission_path(@conn, :show, @submission.id)},
+        %{text: @submission.title, route: Routes.submission_path(@conn, :show, @submission.id), is_visible: @submission.title},
         %{text: "Edit"},
       ])%>
     <% end %>

--- a/lib/web/views/submission_view.ex
+++ b/lib/web/views/submission_view.ex
@@ -38,16 +38,6 @@ defmodule Web.SubmissionView do
     end
   end
 
-  def can_edit?(user, submission) do
-    case Submissions.is_editable?(user, submission) do
-      {:ok, _submission} ->
-        true
-
-      {:error, :not_permitted} ->
-        false
-    end
-  end
-
   def persist_solver_email_on_edit(data) do
     if data.submitter, do: data.submitter.email, else: ""
   end
@@ -168,12 +158,14 @@ defmodule Web.SubmissionView do
     link("Cancel", to: route, class: "btn btn-link")
   end
 
-  def save_draft_button() do
-    submit("Save draft",
-      name: "action",
-      value: "draft",
-      class: "btn btn-outline-secondary mr-2 float-right",
-      formnovalidate: true
-    )
+  def save_draft_button(data) do
+    if Submissions.has_not_been_submitted?(data) do
+      submit("Save draft",
+        name: "action",
+        value: "draft",
+        class: "btn btn-outline-secondary mr-2 float-right",
+        formnovalidate: true
+      )
+    end
   end
 end


### PR DESCRIPTION
submission_controller.ex
* update Submit flash message wording: if editing a submission is not
created
* update saved draft flash wording
* update instances of allowed_to_edit to match newly updated version
without ?
* add check in saving draft that it hasn't already been submitted
* add catch for that clause

submissions.ex
* update allowed_to_edit and is_editable to not have ? since they don't
return a boolean
* create boolean version of allowed_to_edit

submission_view.ex
* add Submissions.has_not_been_submitted conditional to draft button
* remove can_edit? method

_form.html.eex
* add submission data to save_draft_button helper

_actions.html.eex
* replace can_edit? helper with submissions.is_editable

edit.html.eex
* don't show empty title breadcrumb on drafts that don't have a title

submission_controller_test.exs
* update assertion wording
* changing update a submitted submission as a draft to a failure and no
changes
* add test for demonstrating only a review and submit, no save draft button on a submitted submission update

- [x] Tests are included for changes

