### PR TITLE
CHAL-619/Add fetch submission plug

### DIFF
--- a/lib/web/controllers/submission_controller.ex
+++ b/lib/web/controllers/submission_controller.ex
@@ -22,7 +22,7 @@ defmodule Web.SubmissionController do
 
   plug Web.Plugs.FetchPage when action in [:index, :show, :managed_submissions]
 
-  plug(Web.Plugs.FetchSubmission, [submission_id: "id"] when action in [:edit])
+  plug(Web.Plugs.FetchSubmission when action in [:edit])
 
   action_fallback(Web.FallbackController)
 

--- a/lib/web/controllers/submission_controller.ex
+++ b/lib/web/controllers/submission_controller.ex
@@ -22,6 +22,8 @@ defmodule Web.SubmissionController do
 
   plug Web.Plugs.FetchPage when action in [:index, :show, :managed_submissions]
 
+  plug(Web.Plugs.FetchSubmission, [submission_id: "id"] when action in [:edit])
+
   action_fallback(Web.FallbackController)
 
   def index(conn, params = %{"challenge_id" => challenge_id}) do
@@ -252,8 +254,7 @@ defmodule Web.SubmissionController do
   end
 
   def edit(conn, %{"id" => id}) do
-    %{current_user: user} = conn.assigns
-    {:ok, submission} = Submissions.get(id)
+    %{current_user: user, current_submission: submission} = conn.assigns
 
     case Submissions.allowed_to_edit(user, submission) do
       {:ok, submission} ->

--- a/lib/web/controllers/submission_controller.ex
+++ b/lib/web/controllers/submission_controller.ex
@@ -22,7 +22,7 @@ defmodule Web.SubmissionController do
 
   plug Web.Plugs.FetchPage when action in [:index, :show, :managed_submissions]
 
-  plug(Web.Plugs.FetchSubmission when action in [:edit])
+  plug(Web.Plugs.FetchSubmission when action in [:edit, :show, :update, :submit, :delete])
 
   action_fallback(Web.FallbackController)
 
@@ -109,8 +109,7 @@ defmodule Web.SubmissionController do
   end
 
   def show(conn, params = %{"id" => id}) do
-    %{current_user: user, page: page} = conn.assigns
-    {:ok, submission} = Submissions.get(id)
+    %{current_user: user, current_submission: submission, page: page} = conn.assigns
 
     filter = Map.get(params, "filter", %{})
     sort = Map.get(params, "sort", %{})
@@ -277,8 +276,7 @@ defmodule Web.SubmissionController do
   end
 
   def update(conn, %{"id" => id, "action" => "draft", "submission" => submission_params}) do
-    %{current_user: user} = conn.assigns
-    {:ok, submission} = Submissions.get(id)
+    %{current_user: user, current_submission: submission} = conn.assigns
 
     {submitter, _submission_params} = get_params_by_current_user(submission_params, user)
     submission_params = Map.put_new(submission_params, "submitter_id", submitter.id)
@@ -290,11 +288,6 @@ defmodule Web.SubmissionController do
       |> put_flash(:info, "Submission draft saved")
       |> redirect(to: Routes.submission_path(conn, :edit, submission.id))
     else
-      {:error, :not_found} ->
-        conn
-        |> put_flash(:error, "Submission does not exist")
-        |> redirect_by_user_type(user, submission)
-
       {:error, :not_permitted} ->
         conn
         |> put_flash(:error, "Submission cannot be edited")
@@ -311,8 +304,7 @@ defmodule Web.SubmissionController do
   end
 
   def update(conn, %{"id" => id, "action" => "review", "submission" => submission_params}) do
-    %{current_user: user} = conn.assigns
-    {:ok, submission} = Submissions.get(id)
+    %{current_user: user, current_submission: submission} = conn.assigns
 
     with {:ok, submission} <- Submissions.allowed_to_edit(user, submission),
          {:ok, submission} <- Submissions.update_review(submission, submission_params) do
@@ -342,8 +334,7 @@ defmodule Web.SubmissionController do
   end
 
   def submit(conn, %{"id" => id}) do
-    %{current_user: user} = conn.assigns
-    {:ok, submission} = Submissions.get(id)
+    %{current_user: user, current_submission: submission} = conn.assigns
 
     with {:ok, submission} <- Submissions.allowed_to_edit(user, submission),
          {:ok, submission} <- Submissions.submit(submission, Security.extract_remote_ip(conn)) do
@@ -368,8 +359,7 @@ defmodule Web.SubmissionController do
   end
 
   def delete(conn, %{"id" => id}) do
-    %{current_user: user} = conn.assigns
-    {:ok, submission} = Submissions.get(id)
+    %{current_user: user, current_submission: submission} = conn.assigns
 
     with {:ok, submission} <- Submissions.allowed_to_delete(user, submission),
          {:ok, submission} <- Submissions.delete(submission) do

--- a/lib/web/plugs/fetch_submission.ex
+++ b/lib/web/plugs/fetch_submission.ex
@@ -3,18 +3,24 @@ defmodule Web.Plugs.FetchSubmission do
   Fetches a submission and assigns it to the conn.
   """
   import Plug.Conn
+  import Phoenix.Controller
 
   alias ChallengeGov.Submissions
+  alias Web.Router.Helpers, as: Routes
 
   def init(default), do: default
 
-  def call(conn, _opts) do
+  def call(conn, opts) do
+    redirect_route = Keyword.get(opts, :redirect, Routes.dashboard_path(conn, :index))
+
     case Submissions.get(conn.params["id"]) do
       {:ok, submission} ->
         assign(conn, :current_submission, submission)
 
       {:error, :not_found} ->
         conn
+        |> put_flash(:error, "Submission not found")
+        |> redirect(to: redirect_route)
     end
   end
 end

--- a/lib/web/plugs/fetch_submission.ex
+++ b/lib/web/plugs/fetch_submission.ex
@@ -1,0 +1,20 @@
+defmodule Web.Plugs.FetchSubmission do
+  @moduledoc """
+  Fetches a submission and assigns it to the conn.
+  """
+  import Plug.Conn
+
+  alias ChallengeGov.Submissions
+
+  def init(default), do: default
+
+  def call(conn, _opts) do
+    case Submissions.get(conn.params["id"]) do
+      {:ok, submission} ->
+        assign(conn, :current_submission, submission)
+
+      {:error, :not_found} ->
+        conn
+    end
+  end
+end

--- a/test/web/controllers/submission_controller_test.exs
+++ b/test/web/controllers/submission_controller_test.exs
@@ -567,50 +567,50 @@ defmodule Web.SubmissionControllerTest do
       assert redirected_to(conn) === Routes.submission_path(conn, :show, submission.id)
     end
 
-    #   test "attempting to update a submission that was deleted", %{conn: conn} do
-    #     conn = prep_conn(conn)
-    #     %{current_user: user} = conn.assigns
+    # test "attempting to update a submission that was deleted", %{conn: conn} do
+    #   conn = prep_conn(conn)
+    #   %{current_user: user} = conn.assigns
 
-    #     challenge = ChallengeHelpers.create_single_phase_challenge(user, %{user_id: user.id})
+    #   challenge = ChallengeHelpers.create_single_phase_challenge(user, %{user_id: user.id})
 
-    #     submission = SubmissionHelpers.create_submitted_submission(%{}, user, challenge)
+    #   submission = SubmissionHelpers.create_submitted_submission(%{}, user, challenge)
 
-    #     {:ok, submission} = Submissions.delete(submission)
+    #   {:ok, submission} = Submissions.delete(submission)
 
-    #     params = %{
-    #       "action" => "review",
-    #       "submission" => %{
-    #         "title" => "New test title",
-    #         "brief_description" => "New test brief description",
-    #         "description" => "New test description",
-    #         "external_url" => "www.test_example.com"
-    #       }
+    #   params = %{
+    #     "action" => "review",
+    #     "submission" => %{
+    #       "title" => "New test title",
+    #       "brief_description" => "New test brief description",
+    #       "description" => "New test description",
+    #       "external_url" => "www.test_example.com"
     #     }
+    #   }
 
-    #     conn = put(conn, Routes.submission_path(conn, :update, submission.id), params)
+    #   conn = put(conn, Routes.submission_path(conn, :update, submission.id), params)
 
-    #     assert get_flash(conn, :error) === "This submission does not exist"
-    #     assert redirected_to(conn) === Routes.submission_path(conn, :index)
-    #   end
+    #   assert get_flash(conn, :error) === "This submission does not exist"
+    #   assert redirected_to(conn) === Routes.submission_path(conn, :index)
+    # end
 
-    #   test "attempting to update a submission that doesn't exist", %{conn: conn} do
-    #     conn = prep_conn(conn)
+    #     test "attempting to update a submission that doesn't exist", %{conn: conn} do
+    #       conn = prep_conn(conn)
 
-    #     params = %{
-    #       "action" => "review",
-    #       "submission" => %{
-    #         "title" => "New test title",
-    #         "brief_description" => "New test brief description",
-    #         "description" => "New test description",
-    #         "external_url" => "www.test_example.com"
+    #       params = %{
+    #         "action" => "review",
+    #         "submission" => %{
+    #           "title" => "New test title",
+    #           "brief_description" => "New test brief description",
+    #           "description" => "New test description",
+    #           "external_url" => "www.test_example.com"
+    #         }
     #       }
-    #     }
+    # # the following does not execute, but errors, redirects to dashboard and flashes "Submission not found"
+    #       conn = put(conn, Routes.submission_path(conn, :update, 1), params)
 
-    #     conn = put(conn, Routes.submission_path(conn, :update, 1), params)
-
-    #     assert get_flash(conn, :error) === "This submission does not exist"
-    #     assert redirected_to(conn) === Routes.submission_path(conn, :index)
-    #   end
+    #       assert get_flash(conn, :error) === "This submission does not exist"
+    #       assert redirected_to(conn) === Routes.submission_path(conn, :index)
+    #     end
   end
 
   describe "updating judging status" do


### PR DESCRIPTION
### TO DO:

add updates/show/submit/delete to plug (on top and in actions)
merge after controller changes PR #?
re-instate test in test/web/controllers/submission_controller_test.exs: 216, 570 and 596

### Changes:

fetch_submission.ex
* plug that does the query and adds it to conn.assigns

submission_controller.ex
* add it to edit action

### (Nice to have) To Do:

pass in a redirect, but action uses `redirect_by_user_type`

something like:
`plug(Web.Plugs.FetchSubmission when action in [:edit]), redirect: redirect_by_user_type(user, submission)`