### PR TITLE
Bugfix: preload submitter on submission create(s) error cases

### DIFF
--- a/lib/challenge_gov/submissions.ex
+++ b/lib/challenge_gov/submissions.ex
@@ -98,7 +98,11 @@ defmodule ChallengeGov.Submissions do
 
       {:error, _type, changeset, _changes} ->
         changeset = preserve_document_ids_on_error(changeset, params)
-        changeset = %Ecto.Changeset{changeset | data: Repo.preload(changeset.data, [:documents])}
+
+        changeset = %Ecto.Changeset{
+          changeset
+          | data: Repo.preload(changeset.data, [:documents, :submitter])
+        }
 
         {:error, changeset}
     end
@@ -120,7 +124,11 @@ defmodule ChallengeGov.Submissions do
 
       {:error, _type, changeset, _changes} ->
         changeset = preserve_document_ids_on_error(changeset, params)
-        changeset = %Ecto.Changeset{changeset | data: Repo.preload(changeset.data, [:documents])}
+
+        changeset = %Ecto.Changeset{
+          changeset
+          | data: Repo.preload(changeset.data, [:documents, :submitter])
+        }
 
         {:error, changeset}
     end


### PR DESCRIPTION
### Issue:
breaking on admin editing a submission because submitter not preloaded after error found

### Changes:
submissions.ex
* preload submitter in create_draft/review error clause to persist
submitter
