### PR TITLE
Chal 617/preserve document objects error

### DIFF
--- a/lib/challenge_gov/submissions.ex
+++ b/lib/challenge_gov/submissions.ex
@@ -98,7 +98,11 @@ defmodule ChallengeGov.Submissions do
 
       {:error, _type, changeset, _changes} ->
         changeset = preserve_document_ids_on_error(changeset, params)
-        changeset = %Ecto.Changeset{changeset | data: Repo.preload(changeset.data, [:documents])}
+
+        changeset = %Ecto.Changeset{
+          changeset
+          | data: Repo.preload(changeset.data, [:documents, :submitter])
+        }
 
         {:error, changeset}
     end
@@ -120,7 +124,11 @@ defmodule ChallengeGov.Submissions do
 
       {:error, _type, changeset, _changes} ->
         changeset = preserve_document_ids_on_error(changeset, params)
-        changeset = %Ecto.Changeset{changeset | data: Repo.preload(changeset.data, [:documents])}
+
+        changeset = %Ecto.Changeset{
+          changeset
+          | data: Repo.preload(changeset.data, [:documents, :submitter])
+        }
 
         {:error, changeset}
     end

--- a/lib/challenge_gov/submissions/submission.ex
+++ b/lib/challenge_gov/submissions/submission.ex
@@ -44,6 +44,7 @@ defmodule ChallengeGov.Submissions.Submission do
     has_one(:invite, SubmissionInvite)
     has_many(:documents, Document)
     field(:document_ids, :map, virtual: true)
+    field(:document_objects, :map, virtual: true)
 
     # Fields
     field(:title, :string)

--- a/lib/web/templates/submission/_form.html.eex
+++ b/lib/web/templates/submission/_form.html.eex
@@ -48,6 +48,15 @@
             <% end %>
           </div>
         <% end) %>
+        <%= Enum.map(@changeset.changes[:document_objects] || [], fn document -> %>
+          <div class="row submission-document-row">
+            <i class="fa fa-paperclip mr-1"></i>
+            <%= link(DocumentView.name(document), to: ChallengeGov.SubmissionDocuments.download_document_url(document), target: "_blank") %>
+            <%= link to: "#", data: [document_id: document.id], class: "submission_uploaded_document_delete" do %>
+              <i class="fa fa-trash"></i>
+            <% end %>
+          </div>
+        <% end) %>
       </div>
     </div>
 


### PR DESCRIPTION
### Issue:
preserved documents on error not displayed and showing unrecognized item error

- [ ] README is up to date
- [ ] Docs are up to date with changes (modules and functions)
- [x] Tests are included for changes
- [ ] Links in emails use the `_url` route helpers
- [ ] Controllers modified contain appropriate authorization plugs
