### PR TITLE
Submission Controller tests: Add fetch submission halt and assert plug actions in tests

### DIFF
--- a/lib/web/plugs/fetch_submission.ex
+++ b/lib/web/plugs/fetch_submission.ex
@@ -21,6 +21,7 @@ defmodule Web.Plugs.FetchSubmission do
         conn
         |> put_flash(:error, "Submission not found")
         |> redirect(to: redirect_route)
+        |> halt()
     end
   end
 end

--- a/test/web/controllers/submission_controller_test.exs
+++ b/test/web/controllers/submission_controller_test.exs
@@ -213,20 +213,21 @@ defmodule Web.SubmissionControllerTest do
                "<i>#{challenge.title}</i>"
     end
 
-    # test "not found viewing a deleted submission", %{conn: conn} do
-    #   conn = prep_conn(conn)
-    #   %{current_user: user} = conn.assigns
+    test "not found viewing a deleted submission", %{conn: conn} do
+      conn = prep_conn(conn)
+      %{current_user: user} = conn.assigns
 
-    #   challenge = ChallengeHelpers.create_single_phase_challenge(user, %{user_id: user.id})
+      challenge = ChallengeHelpers.create_single_phase_challenge(user, %{user_id: user.id})
 
-    #   submission = SubmissionHelpers.create_submitted_submission(%{}, user, challenge)
+      submission = SubmissionHelpers.create_submitted_submission(%{}, user, challenge)
 
-    #   Submissions.delete(submission)
+      Submissions.delete(submission)
 
-    #   conn = get(conn, Routes.submission_path(conn, :show, submission.id))
+      conn = get(conn, Routes.submission_path(conn, :show, submission.id))
 
-    #   assert conn.status === 404
-    # end
+      assert conn.status === 302
+      assert get_flash(conn, :error) === "Submission not found"
+    end
   end
 
   describe "new action" do
@@ -561,54 +562,30 @@ defmodule Web.SubmissionControllerTest do
       assert redirected_to(conn) === Routes.submission_path(conn, :show, submission.id)
     end
 
-    # test "attempting to update a submission that was deleted", %{conn: conn} do
-    #   conn = prep_conn(conn)
-    #   %{current_user: user} = conn.assigns
+    test "attempting to update a submission that was deleted", %{conn: conn} do
+      conn = prep_conn(conn)
+      %{current_user: user} = conn.assigns
 
-    #   challenge = ChallengeHelpers.create_single_phase_challenge(user, %{user_id: user.id})
+      challenge = ChallengeHelpers.create_single_phase_challenge(user, %{user_id: user.id})
 
-    #   submission = SubmissionHelpers.create_submitted_submission(%{}, user, challenge)
+      submission = SubmissionHelpers.create_submitted_submission(%{}, user, challenge)
 
-    #   {:ok, submission} = Submissions.delete(submission)
+      {:ok, submission} = Submissions.delete(submission)
 
-    #   params = %{
-    #     "action" => "review",
-    #     "submission" => %{
-    #       "title" => "New test title",
-    #       "brief_description" => "New test brief description",
-    #       "description" => "New test description",
-    #       "external_url" => "www.test_example.com",
-    #       "terms_accepted" => "true",
-    #       "review_verified" => "true"
-    #     }
-    #   }
+      conn = put(conn, Routes.submission_path(conn, :update, submission.id), %{})
 
-    #   conn = put(conn, Routes.submission_path(conn, :update, submission.id), params)
+      assert conn.status === 302
+      assert get_flash(conn, :error) === "Submission not found"
+    end
 
-    #   assert get_flash(conn, :error) === "This submission does not exist"
-    #   assert redirected_to(conn) === Routes.submission_path(conn, :index)
-    # end
+    test "attempting to update a submission that doesn't exist", %{conn: conn} do
+      conn = prep_conn(conn)
 
-    #     test "attempting to update a submission that doesn't exist", %{conn: conn} do
-    #       conn = prep_conn(conn)
+      conn = put(conn, Routes.submission_path(conn, :update, 1), %{})
 
-    #       params = %{
-    #         "action" => "review",
-    #         "submission" => %{
-    #           "title" => "New test title",
-    #           "brief_description" => "New test brief description",
-    #           "description" => "New test description",
-    #           "external_url" => "www.test_example.com",
-    #           "terms_accepted" => "true",
-    #           "review_verified" => "true"
-    #         }
-    #       }
-    # # the following does not execute, but errors, redirects to dashboard and flashes "Submission not found"
-    #       conn = put(conn, Routes.submission_path(conn, :update, 1), params)
-
-    #       assert get_flash(conn, :error) === "This submission does not exist"
-    #       assert redirected_to(conn) === Routes.submission_path(conn, :index)
-    #     end
+      assert conn.status === 302
+      assert get_flash(conn, :error) === "Submission not found"
+    end
   end
 
   describe "updating judging status" do


### PR DESCRIPTION
- [ ] README is up to date
- [ ] Docs are up to date with changes (modules and functions)
- [ ] Tests are included for changes
- [ ] Links in emails use the `_url` route helpers
- [ ] Controllers modified contain appropriate authorization plugs
