### PR TITLE
Truncated breadcrumbs for ones that use SharedView helper

### DIFF
--- a/assets/js/app/_expand_breadcrumbs.js
+++ b/assets/js/app/_expand_breadcrumbs.js
@@ -1,0 +1,14 @@
+$(".breadcrumb-item").on("click", ".hidden-breadcrumbs", function(e) {
+  e.preventDefault()
+
+  const parent = $(this).parent()
+  const olGrandParent = $(".breadcrumb")
+  const hiddenBreadcrumbs = $(".truncated-breadcrumbs").data("breadcrumbs")
+
+  const breadcrumbHTML = hiddenBreadcrumbs.reduce((acc, breadcrumb) => {
+    item = `<li class="breadcrumb-item"><a href="${breadcrumb.route}">${breadcrumb.text}</a></li>`
+    return acc + item
+  }, ``)
+
+  parent.replaceWith(breadcrumbHTML)
+})

--- a/assets/js/app/index.js
+++ b/assets/js/app/index.js
@@ -19,6 +19,7 @@ import "./_submission_invite.js";
 import "./_submission_judging_status.js";
 import "./_sub_agency_select.js";
 import "./_timezone.js";
+import "./_expand_breadcrumbs.js";
 
 // Wizard specific JS (Dependent on some above JS)
 import "./_challenge_wizard_details.js"; 

--- a/lib/web/views/shared_view.ex
+++ b/lib/web/views/shared_view.ex
@@ -120,22 +120,47 @@ defmodule Web.SharedView do
   def render_breadcrumbs(breadcrumbs) do
     content_tag :div, class: "row mb-2" do
       content_tag :div, class: "col" do
-        content_tag :ol, class: "breadcrumb" do
-          Enum.map(breadcrumbs, fn breadcrumb ->
-            text = Map.get(breadcrumb, :text)
-            route = Map.get(breadcrumb, :route, nil)
-            is_visible = Map.get(breadcrumb, :is_visible, true)
-
-            if is_visible do
-              content_tag :li, class: "breadcrumb-item #{if is_nil(route), do: 'active'}" do
-                content_tag(:a, text, href: route)
-              end
-            else
-              []
-            end
-          end)
-        end
+        maybe_truncate_breadcrumbs(breadcrumbs)
       end
     end
+  end
+
+  def maybe_truncate_breadcrumbs(breadcrumbs) do
+    visible_breadcrumbs =
+      Enum.filter(breadcrumbs, fn breadcrumb ->
+        !Map.has_key?(breadcrumb, :is_visible) or !!breadcrumb.is_visible
+      end)
+
+    {first, last_two} = Enum.split(visible_breadcrumbs, -2)
+
+    breadcrumbs = if length(visible_breadcrumbs) > 2, do: last_two, else: breadcrumbs
+
+    {:ok, data} = Jason.encode(first)
+
+    content_tag :ol, class: "breadcrumb" do
+      [
+        content_tag(:span, "", class: "truncated-breadcrumbs", "data-breadcrumbs": data),
+        content_tag :li, class: "breadcrumb-item btn-link" do
+          content_tag(:a, "...", href: "", class: "hidden-breadcrumbs")
+        end,
+        get_breadcrumb_html(breadcrumbs)
+      ]
+    end
+  end
+
+  def get_breadcrumb_html(breadcrumbs) do
+    Enum.map(breadcrumbs, fn breadcrumb ->
+      text = Map.get(breadcrumb, :text)
+      route = Map.get(breadcrumb, :route, nil)
+      is_visible = Map.get(breadcrumb, :is_visible, true)
+
+      if is_visible do
+        content_tag :li, class: "breadcrumb-item #{if is_nil(route), do: 'active'}" do
+          content_tag(:a, text, href: route)
+        end
+      else
+        []
+      end
+    end)
   end
 end


### PR DESCRIPTION
shared_view.ex
* break up helper, split off last of breadcrumbs longer than 2, set html
for JS

_expand_breadcrumbs.js
* on ellipsis click replace with html li for each hidden breadcrumb

index.js
* import new _expand_breadcrumbs.js file for use

- [ ] README is up to date
- [ ] Docs are up to date with changes (modules and functions)
- [ ] Tests are included for changes
- [ ] Links in emails use the `_url` route helpers
- [ ] Controllers modified contain appropriate authorization plugs
