### PR TITLE
Correct method of evaluation for review_verify value

### DIFF
--- a/lib/challenge_gov/submissions/submission.ex
+++ b/lib/challenge_gov/submissions/submission.ex
@@ -187,20 +187,36 @@ defmodule ChallengeGov.Submissions.Submission do
     struct = if is_blank?(d), do: add_error(struct, :description, "can't be blank"), else: struct
 
     struct = if ta, do: struct, else: add_error(struct, :terms_accepted, "must be accepted")
-
-    struct = validate_review_verified(struct, %{})
+    struct = validate_review_verified(struct)
 
     struct
   end
 
-  defp validate_review_verified(struct, params) do
-    rv = struct.data.review_verified || params["review_verified"]
+  defp validate_review_verified(struct) do
+    rv = struct.data.review_verified
+    manager_id = struct.data.manager_id
 
     cond do
-      is_nil(struct.data.manager_id) ->
+      is_nil(manager_id) ->
         struct
 
-      !!struct.data.manager_id and rv ->
+      !!manager_id and !!rv ->
+        struct
+
+      true ->
+        add_error(struct, :review_verified, "must verify this submission")
+    end
+  end
+
+  defp validate_review_verified(struct, params) do
+    rv = params["review_verified"]
+    manager_id = struct.data.manager_id
+
+    cond do
+      is_nil(manager_id) ->
+        struct
+
+      !!manager_id and rv === "true" ->
         struct
 
       true ->


### PR DESCRIPTION
### To Do:
terms and verify are both required on the admin form too. But they aren't currently visible. 
Update so they don't show and aren't required for admins.
* when visible
* validation
* errors are showing up
* create (review)/update (review)/submit

- [ ] README is up to date
- [ ] Docs are up to date with changes (modules and functions)
- [ ] Tests are included for changes
- [ ] Links in emails use the `_url` route helpers
- [ ] Controllers modified contain appropriate authorization plugs
