### PR TITLE
Refactor: winners api

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ If you would like to seed the database with a default super-admin user, please s
 ```bash
 mix ecto.create
 mix ecto.migrate
-mix run priv/repo/seeds.exs
+mix run priv/repo/seeds_updated.exs
 ```
 
 Once the database is setup, make sure to install javascript dependencies.

--- a/assets/client/src/components/ChallengeDetails.js
+++ b/assets/client/src/components/ChallengeDetails.js
@@ -252,13 +252,16 @@ export const ChallengeDetails = ({challenge, challengePhases, preview, print, ta
 
   const disableWinners = () => {
     return challengePhases.every(phase => {
-      const phaseWinners = phase.phase_winners
-      return (
-        phaseWinners.length === 0 ||
-        phaseWinners.overview === "" ||
-        !phaseWinners.overview_image_path ||
-        (!!phaseWinners.winners && phaseWinners.winners.length === 0)
-      )
+      const phaseWinner = phase.phase_winner
+      if (!phaseWinner) {
+        return true
+      } else {
+        return (
+          (!phaseWinner.overview || phaseWinner.overview === "") &&
+          !phaseWinner.overview_image_path &&
+          (!!phaseWinner.winners && phaseWinner.winners.length === 0)
+        )
+      }
     })
   }
 

--- a/assets/client/src/components/ChallengeDetails.js
+++ b/assets/client/src/components/ChallengeDetails.js
@@ -19,7 +19,7 @@ import { getPreviousPhase, getCurrentPhase, getNextPhase, phaseInPast, phaseIsCu
 import { ChallengeAnnouncement } from './ChallengeAnnouncement'
 import { ApiUrlContext } from '../ApiUrlContext'
 
-export const ChallengeDetails = ({challenge, winners, preview, print, tab}) => {
+export const ChallengeDetails = ({challenge, challengePhases, preview, print, tab}) => {
   const { apiUrl, imageBase } = useContext(ApiUrlContext)
   const [followTooltipOpen, setFollowTooltipOpen] = useState(false)
 
@@ -250,10 +250,20 @@ export const ChallengeDetails = ({challenge, winners, preview, print, tab}) => {
     }
   }
 
-  const disableWinners = () => !Object.keys(winners).length >= 1;
+  const disableWinners = () => {
+    return challengePhases.every(phase => {
+      const phaseWinners = phase.phase_winners
+      return (
+        phaseWinners.length === 0 ||
+        phaseWinners.overview === "" ||
+        !phaseWinners.overview_image_path ||
+        (!!phaseWinners.winners && phaseWinners.winners.length === 0)
+      )
+    })
+  }
 
   return (
-    (challenge && !!winners) ? (
+    (challenge && !!challengePhases) ? (
       <div className="w-100">
         <section className="hero__wrapper" aria-label="Challenge overview details">
           <section className="hero__content">
@@ -358,7 +368,7 @@ export const ChallengeDetails = ({challenge, winners, preview, print, tab}) => {
             <ContactForm preview={preview} />
           </div>
           <div label="winners" disabled={disableWinners()}>
-            <Winners challenge={challenge} phaseWinners={winners} print={print} />
+            <Winners challenge={challenge} challengePhases={challengePhases} print={print} />
           </div>
         </ChallengeTabs>
       </div>

--- a/assets/client/src/components/challenge_tabs/Winners.js
+++ b/assets/client/src/components/challenge_tabs/Winners.js
@@ -33,7 +33,7 @@ export const Winners = ({challenge, challengePhases, print}) => {
 
   const renderPhaseWinners = () => {
     return challengePhases.map(phase => {
-      const phaseWinner = phase.phase_winners
+      const phaseWinner = phase.phase_winner
       if (phaseWinner && Object.keys(phaseWinner).length >= 1) { 
         return (
           <div key={phaseWinner.id || idx } className="card">
@@ -42,8 +42,9 @@ export const Winners = ({challenge, challengePhases, print}) => {
               <h1 className="my-3">{phaseWinner.phase_title}</h1>
               <div className="my-3" dangerouslySetInnerHTML={{ __html: phaseWinner.overview }}></div>
               {phaseWinner.winners && phaseWinner.winners.length >= 1 &&
-                <div className="detail-section winner-grid">{renderWinners(phaseWinner.winners)}</div>
+                <div className="winners-section">{renderWinners(phaseWinner.winners)}</div>
               }
+            </div>
           </div>
         )
       }

--- a/assets/client/src/components/challenge_tabs/Winners.js
+++ b/assets/client/src/components/challenge_tabs/Winners.js
@@ -34,18 +34,19 @@ export const Winners = ({challenge, challengePhases, print}) => {
   const renderPhaseWinners = () => {
     return challengePhases.map(phase => {
       const phaseWinner = phase.phase_winners
-      return (
-        <div key={phaseWinner.id || idx } className="card">
-          <div className="card-body ql-editor">
-            {renderOverviewImage(phaseWinner)}
-            <h1 className="my-3">{phaseWinner.phase_title}</h1>
-            <div className="my-3" dangerouslySetInnerHTML={{ __html: phaseWinner.overview }}></div>
-            {phaseWinner.winners && phaseWinner.winners.length >= 1 &&
-              <div className="detail-section winner-grid">{renderWinners(phaseWinner.winners)}</div>
-            }
+      if (phaseWinner && Object.keys(phaseWinner).length >= 1) { 
+        return (
+          <div key={phaseWinner.id || idx } className="card">
+            <div className="card-body ql-editor">
+              {renderOverviewImage(phaseWinner)}
+              <h1 className="my-3">{phaseWinner.phase_title}</h1>
+              <div className="my-3" dangerouslySetInnerHTML={{ __html: phaseWinner.overview }}></div>
+              {phaseWinner.winners && phaseWinner.winners.length >= 1 &&
+                <div className="detail-section winner-grid">{renderWinners(phaseWinner.winners)}</div>
+              }
           </div>
-        </div>
-      )
+        )
+      }
     })
   }
 

--- a/assets/client/src/components/challenge_tabs/Winners.js
+++ b/assets/client/src/components/challenge_tabs/Winners.js
@@ -2,7 +2,7 @@ import React, {useContext} from 'react'
 import { ChallengeTab } from "../ChallengeTab"
 import { ApiUrlContext } from '../../ApiUrlContext'
 
-export const Winners = ({challenge, phaseWinners, print}) => {
+export const Winners = ({challenge, challengePhases, print}) => {
   const { imageBase } = useContext(ApiUrlContext)
 
   const renderOverviewImage = (phaseWinner) => {
@@ -32,12 +32,8 @@ export const Winners = ({challenge, phaseWinners, print}) => {
   }
 
   const renderPhaseWinners = () => {
-    console.log({phaseWinners})
-    return Object.keys(phaseWinners).map((value, idx) => {
-      const phaseWinner = phaseWinners[value]
-      console.log({phaseWinner})
-      console.log(Object.keys(phaseWinner).length)
-      console.log(Object.keys(phaseWinner.winners).length)
+    return challengePhases.map(phase => {
+      const phaseWinner = phase.phase_winners
       return (
         <div key={phaseWinner.id || idx } className="card">
           <div className="card-body ql-editor">

--- a/assets/client/src/pages/DetailsPage.js
+++ b/assets/client/src/pages/DetailsPage.js
@@ -7,7 +7,7 @@ import { ApiUrlContext } from '../ApiUrlContext'
 
 export const DetailsPage = (props) => {
   const [currentChallenge, setCurrentChallenge] = useState()
-  const [challengeWinners, setChallengeWinners] = useState([])
+  const [challengePhases, setChallengePhases] = useState([])
   const [loadingState, setLoadingState] = useState(true)
 
   let { challengeId, tab } = useParams();
@@ -27,6 +27,7 @@ export const DetailsPage = (props) => {
       .get(challengeApiPath)
       .then(res => {
         setCurrentChallenge(res.data)
+        setChallengePhases(res.data.phases)
         setLoadingState(false)
       })
       .catch(e => {
@@ -35,29 +36,10 @@ export const DetailsPage = (props) => {
       })
   }, [])
 
-  useEffect(() => {
-    setLoadingState(true)
-    if (!!currentChallenge) {
-      currentChallenge.phases.map(phase => {
-        let phaseWinnerApiPath = apiUrl + `/api/phase/${phase.id}/winners`
-        axios
-          .get(phaseWinnerApiPath)
-          .then(res => {
-            setChallengeWinners([...challengeWinners, res.data])
-            setLoadingState(false)
-          })
-          .catch(e => {
-            setLoadingState(false)
-            console.log({e})
-          })
-      })
-    }
-  }, [currentChallenge])
-
   return (
     <div>
       {currentChallenge &&
-        <ChallengeDetails challenge={currentChallenge} winners={challengeWinners} tab={tab}/>
+        <ChallengeDetails challenge={currentChallenge} challengePhases={challengePhases} tab={tab}/>
       }
     </div>
   )

--- a/assets/client/src/pages/PreviewPage.js
+++ b/assets/client/src/pages/PreviewPage.js
@@ -9,7 +9,7 @@ import { PreviewBanner } from '../components/PreviewBanner';
 export const PreviewPage = () => {
   const [currentChallenge, setCurrentChallenge] = useState()
   const [loadingState, setLoadingState] = useState(null)
-  const [challengeWinners, setChallengeWinners] = useState([])
+  const [challengePhases, setChallengePhases] = useState([])
 
   const isMounted = useRef(false)
 
@@ -28,6 +28,7 @@ export const PreviewPage = () => {
       .get(challengeApiPath)
       .then(res => {
         setCurrentChallenge(res.data)
+        setChallengePhases(res.data.phases)
         setLoadingState(false)
       })
       .catch(e => {
@@ -35,25 +36,6 @@ export const PreviewPage = () => {
         console.log({e})
       })
   }, [])
-
-  useEffect(() => {
-    setLoadingState(true)
-    if (!!currentChallenge) {
-      currentChallenge.phases.map(phase => {
-        let phaseWinnerApiPath = base_url + `/api/phase/${phase.id}/winners`
-        axios
-          .get(phaseWinnerApiPath)
-          .then(res => {
-            setChallengeWinners([...challengeWinners, res.data])
-            setLoadingState(false)
-          })
-          .catch(e => {
-            setLoadingState(false)
-            console.log({e})
-          })
-      })
-    }
-  }, [currentChallenge])
 
   const launchPrintDialogue = () => {
     if (loadingState === false) {
@@ -89,7 +71,7 @@ export const PreviewPage = () => {
       {renderPreviewItems()}
       <div className="row">
         <div className="col">
-          <ChallengeDetails ref={print && launchPrintDialogue()} challenge={currentChallenge} winners={challengeWinners} preview={true} loading={loadingState} print={print} />
+          <ChallengeDetails ref={print && launchPrintDialogue()} challenge={currentChallenge} challengePhases={challengePhases} preview={true} loading={loadingState} print={print} />
         </div>
       </div>
     </div>

--- a/assets/css/app/_main_sidebar.scss
+++ b/assets/css/app/_main_sidebar.scss
@@ -1,0 +1,9 @@
+.main-sidebar {
+  .nav-item.disabled {
+    opacity: .60;
+
+    .nav-link {
+      cursor: not-allowed;
+    }
+  }
+}

--- a/assets/css/app/_message_center.scss
+++ b/assets/css/app/_message_center.scss
@@ -55,4 +55,21 @@
     text-align: center;
     color: #999;
   }
+
+  &__row--unread {
+    background-color: #EDF5FF !important;
+    font-weight: bold;
+  }
+
+  &__actions {
+    a {
+      color: #000000;
+      text-decoration: none !important;
+      margin-right: 1rem;
+    }
+
+    a:last-child {
+      margin-right: 0rem;
+    }
+  }
 }

--- a/assets/css/app/_select2_overrides.scss
+++ b/assets/css/app/_select2_overrides.scss
@@ -1,0 +1,7 @@
+.select2-container .select2-selection--single {
+  height: unset !important;
+}
+
+.select2-results__options {
+  width: 100% !important;
+}

--- a/assets/css/app/index.scss
+++ b/assets/css/app/index.scss
@@ -3,4 +3,6 @@
 @import "base";
 @import "dashboard";
 @import "progress_bar";
+@import "main_sidebar";
 @import "message_center";
+@import "select2_overrides";

--- a/assets/css/public/_details-page.scss
+++ b/assets/css/public/_details-page.scss
@@ -317,6 +317,13 @@
         grid-column: 2;
       }
     }
+
+    .winners-section {
+      display: grid;
+      grid-template-columns: repeat(2, 1fr);
+      row-gap: .5rem;
+
+    }
   }
 
 .follow-tooltip {

--- a/assets/js/app/_custom_select.js
+++ b/assets/js/app/_custom_select.js
@@ -2,6 +2,10 @@
 //   width: "100%"
 // })
 
-$(".js-multiselect").select2({
-  width: "100%"
+$(document).ready(function() {
+  $(".js-select2").select2()
+
+  $(".js-multiselect").select2({
+    width: "100%"
+  })
 })

--- a/assets/js/app/_message_center.js
+++ b/assets/js/app/_message_center.js
@@ -1,3 +1,7 @@
+$(".message_center__challenge_filter").on("change", function() {
+  this.form.submit()
+})
+
 $(".message_center__message_form").on("submit", (e) => {
   e.preventDefault()
 

--- a/lib/challenge_gov/challenges.ex
+++ b/lib/challenge_gov/challenges.ex
@@ -911,6 +911,24 @@ defmodule ChallengeGov.Challenges do
     end
   end
 
+  def set_status(current_user, challenge, status, remote_ip) do
+    challenge
+    |> Ecto.Changeset.change()
+    |> Ecto.Changeset.put_change(:status, status)
+    |> Repo.update()
+    |> case do
+      {:ok, challenge} ->
+        add_to_security_log(current_user, challenge, "status_change", remote_ip, %{
+          status: status
+        })
+
+        {:ok, challenge}
+
+      {:error, changeset} ->
+        {:error, changeset}
+    end
+  end
+
   # BOOKMARK: Advanced status functions
   @doc """
   Checks if the challenge should be publicly accessible. Either published or archived

--- a/lib/challenge_gov/challenges.ex
+++ b/lib/challenge_gov/challenges.ex
@@ -481,7 +481,7 @@ defmodule ChallengeGov.Challenges do
       :challenge_owners,
       :challenge_owner_users,
       :events,
-      phases: ^from(p in Phase, order_by: p.start_date),
+      phases: ^from(p in Phase, order_by: p.start_date, preload: [winners: :winners]),
       federal_partners: [:agency, :sub_agency]
     ])
     |> Repo.one()

--- a/lib/challenge_gov/challenges.ex
+++ b/lib/challenge_gov/challenges.ex
@@ -261,7 +261,7 @@ defmodule ChallengeGov.Challenges do
       :sub_agency,
       federal_partners: [:agency, :sub_agency],
       federal_partner_agencies: [:sub_agencies],
-      phases: [:winners],
+      phases: [winners: [:winners]],
       agency: [:sub_agencies]
     ])
   end
@@ -481,7 +481,7 @@ defmodule ChallengeGov.Challenges do
       :challenge_owners,
       :challenge_owner_users,
       :events,
-      phases: ^from(p in Phase, order_by: p.start_date, preload: [winners: :winners]),
+      phases: ^{from(p in Phase, order_by: p.start_date), [winners: :winners]},
       federal_partners: [:agency, :sub_agency]
     ])
     |> Repo.one()

--- a/lib/challenge_gov/challenges.ex
+++ b/lib/challenge_gov/challenges.ex
@@ -254,7 +254,6 @@ defmodule ChallengeGov.Challenges do
   defp base_preload(challenge) do
     preload(challenge, [
       :non_federal_partners,
-      :phases,
       :events,
       :user,
       :challenge_owner_users,
@@ -262,6 +261,7 @@ defmodule ChallengeGov.Challenges do
       :sub_agency,
       federal_partners: [:agency, :sub_agency],
       federal_partner_agencies: [:sub_agencies],
+      phases: [:winners],
       agency: [:sub_agencies]
     ])
   end

--- a/lib/challenge_gov/message_contexts.ex
+++ b/lib/challenge_gov/message_contexts.ex
@@ -9,6 +9,7 @@ defmodule ChallengeGov.MessageContexts do
 
   alias ChallengeGov.Challenges
   alias ChallengeGov.MessageContextStatuses
+  alias ChallengeGov.Messages.Message
   alias ChallengeGov.Messages.MessageContext
 
   def get(id) do
@@ -83,5 +84,18 @@ defmodule ChallengeGov.MessageContexts do
       _ ->
         nil
     end
+  end
+
+  def get_last_author(message_context) do
+    last_message =
+      Message
+      |> preload([:author])
+      |> where([m], m.message_context_id == ^message_context.id)
+      |> last()
+      |> Repo.one()
+
+    last_author = if last_message, do: last_message.author, else: nil
+
+    {:ok, last_author}
   end
 end

--- a/lib/challenge_gov/messages.ex
+++ b/lib/challenge_gov/messages.ex
@@ -2,22 +2,39 @@ defmodule ChallengeGov.Messages do
   @moduledoc """
   Context for Messages
   """
+  import Ecto.Query
+
+  alias Ecto.Multi
   alias ChallengeGov.Repo
 
   alias ChallengeGov.Messages.Message
+  alias ChallengeGov.Messages.MessageContextStatus
 
   def new(), do: Message.changeset(%Message{})
 
   def create(user, context, params) do
-    %Message{}
-    |> Message.create_changeset(user, context, params)
-    |> Repo.insert()
+    message_changeset = Message.create_changeset(%Message{}, user, context, params)
+
+    message_context_status_query =
+      where(MessageContextStatus, [mcs], mcs.message_context_id == ^context.id)
+
+    Multi.new()
+    |> Multi.insert(:message, message_changeset)
+    |> Multi.update_all(:message_context_statuses, message_context_status_query,
+      set: [read: false]
+    )
+    |> Multi.update(:author_message_context_status, fn _changes ->
+      MessageContextStatus
+      |> Repo.get_by(user_id: user.id, message_context_id: context.id)
+      |> Ecto.Changeset.change(read: true)
+    end)
+    |> Repo.transaction()
     |> case do
-      {:ok, message} ->
+      {:ok, %{message: message}} ->
         message = Repo.preload(message, [:author])
         {:ok, message}
 
-      {:error, changeset} ->
+      {:error, _, changeset, _} ->
         {:error, changeset}
     end
   end

--- a/lib/challenge_gov/messages/message_context_status.ex
+++ b/lib/challenge_gov/messages/message_context_status.ex
@@ -16,6 +16,7 @@ defmodule ChallengeGov.Messages.MessageContextStatus do
 
     field(:read, :boolean, default: false)
     field(:starred, :boolean, default: false)
+    field(:archived, :boolean, default: false)
 
     timestamps(type: :utc_datetime_usec)
   end
@@ -24,7 +25,8 @@ defmodule ChallengeGov.Messages.MessageContextStatus do
     struct
     |> cast(params, [
       :read,
-      :starred
+      :starred,
+      :archived
     ])
   end
 

--- a/lib/challenge_gov/submissions.ex
+++ b/lib/challenge_gov/submissions.ex
@@ -62,7 +62,7 @@ defmodule ChallengeGov.Submissions do
     |> where([s], is_nil(s.deleted_at))
     |> where([s], s.submitter_id == ^user_id)
     |> where([s], not is_nil(s.manager_id))
-    |> where([s], s.review_verified == false)
+    |> where([s], s.review_verified == false or is_nil(s.review_verified))
     |> Repo.paginate(opts[:page], opts[:per])
   end
 

--- a/lib/web/controllers/api/winner_controller.ex
+++ b/lib/web/controllers/api/winner_controller.ex
@@ -32,15 +32,16 @@ defmodule Web.Api.WinnerController do
     phase_winner =
       case PhaseWinners.get_by_phase_id(phase_id) do
         {:ok, phase_winner} ->
-          phase_winner
+          conn
+          |> assign(:phase_title, phase_winner.phase.title)
+          |> assign(:phase_winner, phase_winner)
+          |> put_status(:ok)
+          |> render("phase_winner.json")
 
         {:error, :no_phase_winner} ->
-          []
+          conn
+          |> put_status(:ok)
+          |> render("phase_winner.json")
       end
-
-    conn
-    |> assign(:phase_winner, phase_winner)
-    |> put_status(:ok)
-    |> render("phase_winner.json")
   end
 end

--- a/lib/web/controllers/api/winner_controller.ex
+++ b/lib/web/controllers/api/winner_controller.ex
@@ -29,19 +29,18 @@ defmodule Web.Api.WinnerController do
   end
 
   def phase_winners(conn, %{"phase_id" => phase_id}) do
-    phase_winner =
-      case PhaseWinners.get_by_phase_id(phase_id) do
-        {:ok, phase_winner} ->
-          conn
-          |> assign(:phase_title, phase_winner.phase.title)
-          |> assign(:phase_winner, phase_winner)
-          |> put_status(:ok)
-          |> render("phase_winner.json")
+    case PhaseWinners.get_by_phase_id(phase_id) do
+      {:ok, phase_winner} ->
+        conn
+        |> assign(:phase_title, phase_winner.phase.title)
+        |> assign(:winner, phase_winner)
+        |> put_status(:ok)
+        |> render("phase_winner.json")
 
-        {:error, :no_phase_winner} ->
-          conn
-          |> put_status(:ok)
-          |> render("phase_winner.json")
-      end
+      {:error, :no_phase_winner} ->
+        conn
+        |> put_status(:ok)
+        |> render("phase_winner.json")
+    end
   end
 end

--- a/lib/web/controllers/challenge_controller.ex
+++ b/lib/web/controllers/challenge_controller.ex
@@ -1,5 +1,6 @@
 defmodule Web.ChallengeController do
   use Web, :controller
+  use Phoenix.HTML
 
   alias ChallengeGov.Challenges
   alias ChallengeGov.Security
@@ -155,8 +156,9 @@ defmodule Web.ChallengeController do
     with {:ok, challenge} <- Challenges.get(id),
          {:ok, challenge} <- Challenges.allowed_to_edit(user, challenge) do
       conn
-      |> assign(:user, user)
       |> assign(:challenge, challenge)
+      |> maybe_reset_challenge_status(user, challenge)
+      |> assign(:user, user)
       |> assign(:path, Routes.challenge_path(conn, :update, id))
       |> assign(:action, action_name(conn))
       |> assign(:show_info, false)
@@ -455,4 +457,23 @@ defmodule Web.ChallengeController do
       |> redirect(to: Routes.challenge_path(conn, :edit, challenge.id, section))
     end
   end
+
+  defp maybe_reset_challenge_status(
+         conn,
+         user = %{role: "challenge_owner"},
+         challenge = %{status: "gsa_review"}
+       ) do
+    remote_ip = Security.extract_remote_ip(conn)
+    {:ok, challenge} = Challenges.set_status(user, challenge, "draft", remote_ip)
+
+    conn
+    |> put_flash(:warning, [
+      content_tag(:span, "Challenge Removed from Queue", class: "h4"),
+      content_tag(:br, ""),
+      "Once edits are made you will need to resubmit this challenge for GSA approval"
+    ])
+    |> assign(:challenge, challenge)
+  end
+
+  defp maybe_reset_challenge_status(conn, _user, _challenge), do: conn
 end

--- a/lib/web/controllers/challenge_controller.ex
+++ b/lib/web/controllers/challenge_controller.ex
@@ -460,7 +460,7 @@ defmodule Web.ChallengeController do
 
   defp maybe_reset_challenge_status(
          conn,
-         user = %{role: "challenge_owner"},
+         user,
          challenge = %{status: "gsa_review"}
        ) do
     remote_ip = Security.extract_remote_ip(conn)

--- a/lib/web/controllers/message_context_controller.ex
+++ b/lib/web/controllers/message_context_controller.ex
@@ -12,8 +12,12 @@ defmodule Web.MessageContextController do
     filter = Map.get(params, "filter", %{})
     message_context_statuses = MessageContextStatuses.all_for_user(user, filter: filter)
 
+    challenges = MessageContextStatuses.get_challenges_for_user(user)
+
     conn
     |> assign(:message_context_statuses, message_context_statuses)
+    |> assign(:challenges, challenges)
+    |> assign(:filter, filter)
     |> render("index.html")
   end
 
@@ -21,6 +25,9 @@ defmodule Web.MessageContextController do
     %{current_user: user} = conn.assigns
 
     {:ok, message_context} = MessageContexts.get(id)
+
+    {:ok, message_context_status} = MessageContextStatuses.get(user, message_context)
+    {:ok, _message_context_status} = MessageContextStatuses.mark_read(message_context_status)
 
     message_changeset = Messages.new()
 

--- a/lib/web/controllers/message_context_status_controller.ex
+++ b/lib/web/controllers/message_context_status_controller.ex
@@ -1,0 +1,41 @@
+defmodule Web.MessageContextStatusController do
+  use Web, :controller
+
+  alias ChallengeGov.MessageContextStatuses
+
+  def mark_read(conn, %{"id" => id}) do
+    {:ok, message_context_status} = MessageContextStatuses.get(id)
+    {:ok, _message_context_status} = MessageContextStatuses.mark_read(message_context_status)
+
+    conn
+    |> put_flash(:info, "Message thread marked as read")
+    |> redirect(to: Routes.message_context_path(conn, :index))
+  end
+
+  def mark_unread(conn, %{"id" => id}) do
+    {:ok, message_context_status} = MessageContextStatuses.get(id)
+    {:ok, _message_context_status} = MessageContextStatuses.mark_unread(message_context_status)
+
+    conn
+    |> put_flash(:info, "Message thread marked as unread")
+    |> redirect(to: Routes.message_context_path(conn, :index))
+  end
+
+  def archive(conn, %{"id" => id}) do
+    {:ok, message_context_status} = MessageContextStatuses.get(id)
+    {:ok, _message_context_status} = MessageContextStatuses.archive(message_context_status)
+
+    conn
+    |> put_flash(:info, "Message thread archived")
+    |> redirect(to: Routes.message_context_path(conn, :index))
+  end
+
+  def unarchive(conn, %{"id" => id}) do
+    {:ok, message_context_status} = MessageContextStatuses.get(id)
+    {:ok, _message_context_status} = MessageContextStatuses.unarchive(message_context_status)
+
+    conn
+    |> put_flash(:info, "Message thread unarchived")
+    |> redirect(to: Routes.message_context_path(conn, :index))
+  end
+end

--- a/lib/web/router.ex
+++ b/lib/web/router.ex
@@ -175,6 +175,17 @@ defmodule Web.Router do
 
     resources("/messages", MessageContextController, only: [:index, :show, :new, :create])
 
+    post("/message_context_statuses/:id/mark_read", MessageContextStatusController, :mark_read)
+
+    post(
+      "/message_context_statuses/:id/mark_unread",
+      MessageContextStatusController,
+      :mark_unread
+    )
+
+    post("/message_context_statuses/:id/archive", MessageContextStatusController, :archive)
+    post("/message_context_statuses/:id/unarchive", MessageContextStatusController, :unarchive)
+
     resources("/site_content", SiteContentController, [:index, :show, :edit, :update])
   end
 

--- a/lib/web/templates/challenge/index.html.eex
+++ b/lib/web/templates/challenge/index.html.eex
@@ -26,7 +26,7 @@
     <div class="row mb-2">
       <div class="col-sm-6">
         <h1 class="m-0 text-dark">
-          <span>Challenges</span>
+          <span>All Challenges</span>
           <div class="btn-group">
             <%= link "New", to: Routes.challenge_path(@conn, :new, show_info: true), class: "btn btn-primary" %>
           </div>

--- a/lib/web/templates/layout/_header.html.eex
+++ b/lib/web/templates/layout/_header.html.eex
@@ -20,6 +20,6 @@
         </div>
       </div>
     </form>
-    <%= link("Login", to: Routes.session_path(@conn, :new), class: "header__login") %>
+    <%= link("My account", to: Routes.session_path(@conn, :new), class: "header__login") %>
   </div>
 </nav>

--- a/lib/web/templates/layout/app.html.eex
+++ b/lib/web/templates/layout/app.html.eex
@@ -139,7 +139,17 @@
               </div>
             </div>
           </div>
-          <% end %>
+        <% end %>
+
+        <%= if get_flash(@conn, :warning) do %>
+          <div class="content-header">
+            <div class="container-fluid">
+              <div class="callout callout-warning">
+                <i class="fa fa-exclamation-circle"></i> <%= get_flash(@conn, :warning) %>
+              </div>
+            </div>
+          </div>
+        <% end %>
       <%= @inner_content %>          
       </div>
       <aside class="control-sidebar control-sidebar-light">

--- a/lib/web/templates/layout/app.html.eex
+++ b/lib/web/templates/layout/app.html.eex
@@ -89,12 +89,7 @@
                     <% end %>
                   </li>
                 <% end %>
-                <li class="nav-item">
-                  <%= link(to: Routes.message_context_path(@conn, :index), class: "nav-link #{tab_selected(@conn, "messages")}") do %>
-                    <i class="nav-icon fas fa-envelope"></i>
-                    <p>Message Center</p>
-                  <% end %>
-                </li>
+                <%= render_message_center_icon(@conn, u) %>
               </ul>
             </nav>
             <%= if ChallengeGov.Accounts.has_admin_access?(u) do %>

--- a/lib/web/templates/message_context/index.html.eex
+++ b/lib/web/templates/message_context/index.html.eex
@@ -17,15 +17,21 @@
 
   <section class="content">
     <div class="container-fluid">
-      <div class="row mb-3">
-        <div class="col">
-          <%= link("New Message", to: Routes.message_context_path(@conn, :new, context: "challenge"), class: "btn btn-primary") %>
+      <%= form_for(@conn, Routes.message_context_path(@conn, :index, filter: @filter), [method: :get, as: :filter], fn f -> %>
+        <div class="row mb-3">
+          <div class="col">
+            <%= link("New Message", to: Routes.message_context_path(@conn, :new, context: "challenge"), class: "btn btn-primary mr-3") %>
+              <%= select(f, :challenge_id, Enum.map(@challenges, &{&1.title, &1.id}), value: @filter["challenge_id"], prompt: "Filter by challenge", class: "js-select2 message_center__challenge_filter") %>
+          </div>
+          <div class="col text-right">
+            <%= link("All", to: Routes.message_context_path(@conn, :index), class: "btn #{filter_active_class(@conn, "all")}") %>
+            <%= link("Starred", to: Routes.message_context_path(@conn, :index, filter: %{starred: true}), class: "btn #{filter_active_class(@conn, "starred")}") %>
+            <%= link("Unread", to: Routes.message_context_path(@conn, :index, filter: %{read: false}), class: "btn #{filter_active_class(@conn, "read")}") %>
+            <%= link("Archived", to: Routes.message_context_path(@conn, :index, filter: %{archived: true}), class: "btn #{filter_active_class(@conn, "archived")}") %>
+          </div>
         </div>
-        <div class="col text-right">
-          <%= link("All", to: Routes.message_context_path(@conn, :index), class: "btn btn-link #{filter_active_class(@conn, "all")}") %>
-          <%= link("Starred", to: Routes.message_context_path(@conn, :index, filter: %{starred: true}), class: "btn btn-link #{filter_active_class(@conn, "starred")}") %>
-        </div>
-      </div>
+      <% end) %>
+
       <div class="row">
         <div class="col-md-12">
           <div class="card">
@@ -37,6 +43,8 @@
                     <th>Date</th>
                     <th>Challenge title</th>
                     <th>Audience</th>
+                    <th>Last author</th>
+                    <th>Last author role</th>
                     <th>Message snippet</th>
                     <th></th>
                   </tr>
@@ -44,7 +52,7 @@
 
                 <tbody>
                   <%= Enum.map @message_context_statuses, fn (message_context_status) -> %>
-                    <tr>
+                    <tr class=<%= maybe_unread_class(message_context_status) %>>
                       <td>
                         <input type="checkbox" class="mr-2">
                         <%= render_star(message_context_status) %>
@@ -52,8 +60,12 @@
                       <td><%= Web.SharedView.local_datetime_tag(message_context_status.updated_at) %></td>
                       <td><%= display_challenge_title_link(message_context_status.context) %></td>
                       <td><%= display_audience(message_context_status.context) %></td>
+                      <td><%= display_last_author_name(message_context_status.context) %></td>
+                      <td><%= display_last_author_role(message_context_status.context) %></td>
                       <td class="message_center__snippet"><%= display_last_message_snippet(message_context_status.context) %></td>
-                      <td>
+                      <td class="message_center__actions">
+                        <%= render_archive_icon(message_context_status) %>
+                        <%= render_read_icon(message_context_status) %>
                         <%= link("", to: Routes.message_context_path(@conn, :show, message_context_status.message_context_id), class: "far fa-eye text-black text-decoration-none") %>
                       </td>
                     </tr>

--- a/lib/web/templates/submission/_form.html.eex
+++ b/lib/web/templates/submission/_form.html.eex
@@ -63,7 +63,7 @@
     <%= FormView.text_field(f, :external_url, label: "External URL (optional)") %>
     <br/>
 
-    <%= accept_terms(@conn, f, @data.submitter_id, @user.id, @challenge) %>
+    <%= accept_terms(@conn, f, @user, @challenge) %>
     <%= verify_review(f, @user.id, @data) %>
 
     <%= cancel_button(@conn, @action, @challenge, @phase, @user) %>

--- a/lib/web/views/account_view.ex
+++ b/lib/web/views/account_view.ex
@@ -21,4 +21,10 @@ defmodule Web.AccountView do
   def full_name(user) do
     "#{user.first_name} #{user.last_name}"
   end
+
+  def role_display(user) do
+    user.role
+    |> String.replace("_", " ")
+    |> String.capitalize()
+  end
 end

--- a/lib/web/views/api/phase_view.ex
+++ b/lib/web/views/api/phase_view.ex
@@ -10,7 +10,7 @@ defmodule Web.Api.PhaseView do
       open_to_submissions: phase.open_to_submissions,
       judging_criteria: HtmlSanitizeEx.basic_html(phase.judging_criteria),
       how_to_enter: HtmlSanitizeEx.basic_html(phase.how_to_enter),
-      phase_winners:
+      phase_winner:
         render_one(phase.winners, Web.Api.WinnerView, "phase_winner.json", %{
           phase_title: phase.title
         })

--- a/lib/web/views/api/phase_view.ex
+++ b/lib/web/views/api/phase_view.ex
@@ -9,7 +9,11 @@ defmodule Web.Api.PhaseView do
       end_date: phase.end_date,
       open_to_submissions: phase.open_to_submissions,
       judging_criteria: HtmlSanitizeEx.basic_html(phase.judging_criteria),
-      how_to_enter: HtmlSanitizeEx.basic_html(phase.how_to_enter)
+      how_to_enter: HtmlSanitizeEx.basic_html(phase.how_to_enter),
+      phase_winners:
+        render_one(phase.winners, Web.Api.WinnerView, "phase_winner.json", %{
+          phase_title: phase.title
+        })
     }
   end
 end

--- a/lib/web/views/api/winner_view.ex
+++ b/lib/web/views/api/winner_view.ex
@@ -11,14 +11,14 @@ defmodule Web.Api.WinnerView do
     %{}
   end
 
-  def render("phase_winner.json", _assigns = %{phase_winner: phase_winner}) do
+  def render("phase_winner.json", _assigns = %{winner: phase_winner, phase_title: phase_title}) do
     %{
       id: phase_winner.id,
       inserted_at: phase_winner.inserted_at,
       overview: phase_winner.overview,
       overview_delta: phase_winner.overview_delta,
       overview_image_path: phase_winner.overview_image_path,
-      phase_title: phase_winner.phase.title,
+      phase_title: phase_title,
       phase_id: phase_winner.phase_id,
       status: phase_winner.status,
       updated_at: phase_winner.updated_at,

--- a/lib/web/views/api/winner_view.ex
+++ b/lib/web/views/api/winner_view.ex
@@ -9,7 +9,7 @@ defmodule Web.Api.WinnerView do
 
   def render(
         "phase_winner.json",
-        _assigns = %{phase_winner: phase_winner, phase_title: phase_title}
+        _assigns = %{winner: phase_winner, phase_title: phase_title}
       ) do
     %{
       id: phase_winner.id,

--- a/lib/web/views/api/winner_view.ex
+++ b/lib/web/views/api/winner_view.ex
@@ -7,11 +7,10 @@ defmodule Web.Api.WinnerView do
     %{image_path: Storage.url(image_path)}
   end
 
-  def render("phase_winner.json", _assigns = %{phase_winner: []}) do
-    %{}
-  end
-
-  def render("phase_winner.json", _assigns = %{winner: phase_winner, phase_title: phase_title}) do
+  def render(
+        "phase_winner.json",
+        _assigns = %{phase_winner: phase_winner, phase_title: phase_title}
+      ) do
     %{
       id: phase_winner.id,
       inserted_at: phase_winner.inserted_at,
@@ -25,6 +24,10 @@ defmodule Web.Api.WinnerView do
       uuid: phase_winner.uuid,
       winners: render_many(phase_winner.winners, __MODULE__, "winners.json")
     }
+  end
+
+  def render("phase_winner.json", _assigns) do
+    %{}
   end
 
   def render("winners.json", %{winner: winner}) do

--- a/lib/web/views/bulletin_view.ex
+++ b/lib/web/views/bulletin_view.ex
@@ -2,4 +2,5 @@ defmodule Web.BulletinView do
   use Web, :view
 
   alias Web.FormView
+  alias Web.SharedView
 end

--- a/lib/web/views/event_view.ex
+++ b/lib/web/views/event_view.ex
@@ -2,4 +2,5 @@ defmodule Web.EventView do
   use Web, :view
 
   alias Web.FormView
+  alias Web.SharedView
 end

--- a/lib/web/views/layout_view.ex
+++ b/lib/web/views/layout_view.ex
@@ -2,6 +2,7 @@ defmodule Web.LayoutView do
   use Web, :view
 
   alias ChallengeGov.Accounts
+  alias ChallengeGov.MessageContextStatuses
   alias ChallengeGov.Recaptcha
   alias Web.AccountView
   alias Web.PageTitle
@@ -68,6 +69,33 @@ defmodule Web.LayoutView do
 
       _ ->
         ""
+    end
+  end
+
+  def render_message_center_icon(conn, user) do
+    nav_item_classes = "nav-item"
+    link_classes = "nav-link #{tab_selected(conn, "messages")}"
+
+    [route, nav_item_classes] =
+      if !MessageContextStatuses.has_messages?(user) and Accounts.is_solver?(user) do
+        [
+          "#",
+          nav_item_classes <> " disabled"
+        ]
+      else
+        [
+          Routes.message_context_path(conn, :index),
+          nav_item_classes
+        ]
+      end
+
+    content_tag :li, class: nav_item_classes do
+      link to: route, class: link_classes do
+        [
+          content_tag(:i, "", class: "nav-icon fas fa-envelope"),
+          content_tag(:p, "Message Center")
+        ]
+      end
     end
   end
 

--- a/lib/web/views/message_contex_status_view.ex
+++ b/lib/web/views/message_contex_status_view.ex
@@ -1,0 +1,3 @@
+defmodule Web.MessageContextStatusView do
+  use Web, :view
+end

--- a/lib/web/views/submission_view.ex
+++ b/lib/web/views/submission_view.ex
@@ -166,8 +166,9 @@ defmodule Web.SubmissionView do
     link("Cancel", to: route, class: "btn btn-link")
   end
 
-  def accept_terms(conn, form, submitter_id, user_id, challenge) do
-    if is_nil(submitter_id) or submitter_id == user_id do
+  def accept_terms(conn, form, user, challenge) do
+    # show for solvers even on editing
+    if Accounts.is_solver?(user) do
       content_tag(:div, class: "form-group") do
         content_tag(:div, class: "col") do
           [

--- a/priv/repo/migrations/20210622184536_challenge_prize_total_0_default.exs
+++ b/priv/repo/migrations/20210622184536_challenge_prize_total_0_default.exs
@@ -2,7 +2,7 @@ defmodule ChallengeGov.Repo.Migrations.ChallengePrizeTotal0Default do
   use Ecto.Migration
 
   def change do
-    execute "update challenges set prize_total = 0 where prize_total = null;", ""
+    execute "update challenges set prize_total = 0 where prize_total is null;", ""
 
     alter table(:challenges) do
       modify(:prize_total, :integer, null: false)

--- a/priv/repo/migrations/20210622184536_challenge_prize_total_0_default.exs
+++ b/priv/repo/migrations/20210622184536_challenge_prize_total_0_default.exs
@@ -1,0 +1,11 @@
+defmodule ChallengeGov.Repo.Migrations.ChallengePrizeTotal0Default do
+  use Ecto.Migration
+
+  def change do
+    execute "update challenges set prize_total = 0 where prize_total = null;", ""
+
+    alter table(:challenges) do
+      modify(:prize_total, :integer, null: false)
+    end
+  end
+end

--- a/priv/repo/migrations/20210701020028_add_archived_to_message_context_status.exs
+++ b/priv/repo/migrations/20210701020028_add_archived_to_message_context_status.exs
@@ -1,0 +1,9 @@
+defmodule ChallengeGov.Repo.Migrations.AddArchivedToMessageContextStatus do
+  use Ecto.Migration
+
+  def change do
+    alter table(:message_context_statuses) do
+      add :archived, :boolean, default: false
+    end
+  end
+end

--- a/test/challenge_gov/message_context_statuses_test.exs
+++ b/test/challenge_gov/message_context_statuses_test.exs
@@ -1,0 +1,230 @@
+defmodule ChallengeGov.MessageContextStatusesTest do
+  use ChallengeGov.DataCase
+
+  alias ChallengeGov.Repo
+
+  alias ChallengeGov.MessageContexts
+  alias ChallengeGov.MessageContextStatuses
+
+  alias ChallengeGov.TestHelpers.AccountHelpers
+  alias ChallengeGov.TestHelpers.ChallengeHelpers
+  alias ChallengeGov.TestHelpers.MessageContextStatusHelpers
+  alias ChallengeGov.TestHelpers.SubmissionHelpers
+
+  @challenge_owner_params %{
+    email: "challenge_owner@example.com",
+    role: "challenge_owner"
+  }
+
+  @solver_params %{
+    email: "solver_1@example.com",
+    role: "solver"
+  }
+
+  defp create_message_context_status() do
+    user_challenge_owner = AccountHelpers.create_user(@challenge_owner_params)
+    user_solver = AccountHelpers.create_user(@solver_params)
+
+    challenge =
+      ChallengeHelpers.create_single_phase_challenge(user_challenge_owner, %{
+        user_id: user_challenge_owner.id
+      })
+
+    {:ok, message_context} =
+      MessageContexts.create(%{
+        "context" => "challenge",
+        "context_id" => challenge.id,
+        "audience" => ["solvers"]
+      })
+
+    message_context = Repo.preload(message_context, [:statuses])
+
+    assert length(message_context.statuses) == 1
+
+    _submission = SubmissionHelpers.create_submitted_submission(%{}, user_solver, challenge)
+
+    {:ok, message_context_status} = MessageContextStatuses.create(user_solver, message_context)
+
+    message_context = Repo.preload(message_context, [:statuses], force: true)
+
+    assert length(message_context.statuses) == 2
+
+    %{
+      message_context: message_context,
+      message_context_status: message_context_status
+    }
+  end
+
+  describe "creating a message context status" do
+    test "success" do
+      %{
+        message_context: message_context,
+        message_context_status: message_context_status
+      } = create_message_context_status()
+
+      assert message_context_status.message_context_id == message_context.id
+      refute message_context_status.read
+      refute message_context_status.starred
+    end
+  end
+
+  describe "marking context status as read" do
+    test "success: set" do
+      %{
+        message_context_status: message_context_status
+      } = create_message_context_status()
+
+      {:ok, message_context_status} = MessageContextStatuses.mark_read(message_context_status)
+
+      assert message_context_status.read
+    end
+
+    test "success: toggle" do
+      %{
+        message_context_status: message_context_status
+      } = create_message_context_status()
+
+      {:ok, message_context_status} = MessageContextStatuses.toggle_read(message_context_status)
+
+      assert message_context_status.read
+    end
+  end
+
+  describe "marking context status as unread" do
+    test "success: set" do
+      %{
+        message_context_status: message_context_status
+      } = create_message_context_status()
+
+      {:ok, message_context_status} = MessageContextStatuses.mark_read(message_context_status)
+      assert message_context_status.read
+
+      {:ok, message_context_status} = MessageContextStatuses.mark_unread(message_context_status)
+      refute message_context_status.read
+    end
+
+    test "success: toggle" do
+      %{
+        message_context_status: message_context_status
+      } = create_message_context_status()
+
+      {:ok, message_context_status} = MessageContextStatuses.toggle_read(message_context_status)
+      assert message_context_status.read
+
+      {:ok, message_context_status} = MessageContextStatuses.toggle_read(message_context_status)
+      refute message_context_status.read
+    end
+  end
+
+  describe "marking context status as starred" do
+    test "success" do
+      %{
+        message_context_status: message_context_status
+      } = create_message_context_status()
+
+      {:ok, message_context_status} =
+        MessageContextStatuses.toggle_starred(message_context_status)
+
+      assert message_context_status.starred
+    end
+  end
+
+  describe "marking context status as unstarred" do
+    test "success" do
+      %{
+        message_context_status: message_context_status
+      } = create_message_context_status()
+
+      {:ok, message_context_status} =
+        MessageContextStatuses.toggle_starred(message_context_status)
+
+      {:ok, message_context_status} =
+        MessageContextStatuses.toggle_starred(message_context_status)
+
+      refute message_context_status.starred
+    end
+  end
+
+  describe "marking context status as archived" do
+    test "success: set" do
+      %{
+        message_context_status: message_context_status
+      } = create_message_context_status()
+
+      {:ok, message_context_status} = MessageContextStatuses.archive(message_context_status)
+
+      assert message_context_status.archived
+    end
+
+    test "success: toggle" do
+      %{
+        message_context_status: message_context_status
+      } = create_message_context_status()
+
+      {:ok, message_context_status} =
+        MessageContextStatuses.toggle_archived(message_context_status)
+
+      assert message_context_status.archived
+    end
+  end
+
+  describe "marking context status as unarchived" do
+    test "success: set" do
+      %{
+        message_context_status: message_context_status
+      } = create_message_context_status()
+
+      {:ok, message_context_status} = MessageContextStatuses.archive(message_context_status)
+
+      {:ok, message_context_status} = MessageContextStatuses.unarchive(message_context_status)
+
+      refute message_context_status.archived
+    end
+
+    test "success: toggle" do
+      %{
+        message_context_status: message_context_status
+      } = create_message_context_status()
+
+      {:ok, message_context_status} =
+        MessageContextStatuses.toggle_archived(message_context_status)
+
+      {:ok, message_context_status} =
+        MessageContextStatuses.toggle_archived(message_context_status)
+
+      refute message_context_status.archived
+    end
+  end
+
+  describe "checking if a user has message context statuses" do
+    test "success: no messages" do
+      user = AccountHelpers.create_user()
+
+      refute MessageContextStatuses.has_messages?(user)
+    end
+
+    test "success: has messages" do
+      %{
+        user_solver: user_solver
+      } = MessageContextStatusHelpers.create_message_context_status()
+
+      assert MessageContextStatuses.has_messages?(user_solver)
+    end
+  end
+
+  describe "fetching all challenge ids from messages for a user" do
+    test "success" do
+      %{
+        challenge: challenge,
+        user_solver: user_solver
+      } = MessageContextStatusHelpers.create_message_context_status()
+
+      fetched_challenge =
+        user_solver
+        |> MessageContextStatuses.get_challenges_for_user()
+        |> Enum.at(0)
+
+      assert fetched_challenge.id == challenge.id
+    end
+  end
+end

--- a/test/challenge_gov/message_contexts_test.exs
+++ b/test/challenge_gov/message_contexts_test.exs
@@ -1,11 +1,13 @@
 defmodule ChallengeGov.MessageContextsTest do
   use ChallengeGov.DataCase
 
+  alias ChallengeGov.Messages
   alias ChallengeGov.MessageContexts
   alias ChallengeGov.MessageContextStatuses
 
   alias ChallengeGov.TestHelpers.AccountHelpers
   alias ChallengeGov.TestHelpers.ChallengeHelpers
+  alias ChallengeGov.TestHelpers.MessageContextStatusHelpers
   alias ChallengeGov.TestHelpers.SubmissionHelpers
 
   describe "creating a message context" do
@@ -58,6 +60,37 @@ defmodule ChallengeGov.MessageContextsTest do
         })
 
       assert message_context.id == message_context_2.id
+    end
+  end
+
+  describe "retrieving the last author" do
+    test "success" do
+      %{
+        message_context: message_context,
+        user_challenge_owner: user_challenge_owner,
+        user_solver: user_solver
+      } = MessageContextStatusHelpers.create_message_context_status()
+
+      {:ok, last_author} = MessageContexts.get_last_author(message_context)
+      assert last_author == nil
+
+      {:ok, _message} =
+        Messages.create(user_challenge_owner, message_context, %{
+          "content" => "Test",
+          "content_delta" => "Test"
+        })
+
+      {:ok, last_author} = MessageContexts.get_last_author(message_context)
+      assert last_author.id == user_challenge_owner.id
+
+      {:ok, _message} =
+        Messages.create(user_solver, message_context, %{
+          "content" => "Test",
+          "content_delta" => "Test"
+        })
+
+      {:ok, last_author} = MessageContexts.get_last_author(message_context)
+      assert last_author.id == user_solver.id
     end
   end
 end

--- a/test/challenge_gov/messages_test.exs
+++ b/test/challenge_gov/messages_test.exs
@@ -1,44 +1,99 @@
 defmodule ChallengeGov.MessagesTest do
-  # use ChallengeGov.DataCase
+  use ChallengeGov.DataCase
 
-  # alias ChallengeGov.Repo
+  alias ChallengeGov.Repo
 
-  # alias ChallengeGov.Messages
-  # alias ChallengeGov.MessageContexts
-  # alias ChallengeGov.MessageContextStatuses
+  alias ChallengeGov.Messages
+  alias ChallengeGov.MessageContexts
+  alias ChallengeGov.MessageContextStatuses
 
-  # alias ChallengeGov.TestHelpers.AccountHelpers
-  # alias ChallengeGov.TestHelpers.ChallengeHelpers
+  alias ChallengeGov.TestHelpers.AccountHelpers
+  alias ChallengeGov.TestHelpers.ChallengeHelpers
+  alias ChallengeGov.TestHelpers.SubmissionHelpers
 
-  # describe "creating a message" do
-  #   test "success" do
-  #     user = AccountHelpers.create_user()
-  #     user_2 = AccountHelpers.create_user(%{email: "user2@example.com"})
-  #     challenge = ChallengeHelpers.create_single_phase_challenge(user, %{user_id: user.id})
+  @challenge_owner_params %{
+    email: "challenge_owner@example.com",
+    role: "challenge_owner"
+  }
 
-  #     {:ok, message} =
-  #       Messages.create(user, "challenge", challenge.id, %{
-  #         content: "Test",
-  #         content_delta: "Test"
-  #       })
+  @solver_params %{
+    email: "solver_1@example.com",
+    role: "solver"
+  }
 
-  #     assert message.content == "Test"
+  defp create_message_context_status() do
+    user_challenge_owner = AccountHelpers.create_user(@challenge_owner_params)
+    user_solver = AccountHelpers.create_user(@solver_params)
 
-  #     {:ok, message_2} =
-  #       Messages.create(user_2, "challenge", challenge.id, %{
-  #         content: "Test 2",
-  #         content_delta: "Test 2"
-  #       })
+    challenge =
+      ChallengeHelpers.create_single_phase_challenge(user_challenge_owner, %{
+        user_id: user_challenge_owner.id
+      })
 
-  #     assert message_2.content == "Test 2"
-  #     assert message.message_context_id == message_2.message_context_id
+    {:ok, message_context} =
+      MessageContexts.create(%{
+        "context" => "challenge",
+        "context_id" => challenge.id,
+        "audience" => ["solvers"]
+      })
 
-  #     {:ok, message_context} = MessageContexts.get("challenge", challenge.id)
-  #     message_context = Repo.preload(message_context, [:messages])
-  #     assert length(message_context.messages) == 2
+    message_context = Repo.preload(message_context, [:statuses])
 
-  #     {:ok, _message_context_status} = MessageContextStatuses.get(user, message_context)
-  #     {:ok, _message_context_status_2} = MessageContextStatuses.get(user_2, message_context)
-  #   end
-  # end
+    assert length(message_context.statuses) == 1
+
+    _submission = SubmissionHelpers.create_submitted_submission(%{}, user_solver, challenge)
+
+    {:ok, message_context_status} = MessageContextStatuses.create(user_solver, message_context)
+
+    message_context = Repo.preload(message_context, [:statuses], force: true)
+
+    assert length(message_context.statuses) == 2
+
+    %{
+      user_challenge_owner: user_challenge_owner,
+      user_solver: user_solver,
+      message_context: message_context,
+      message_context_status: message_context_status
+    }
+  end
+
+  describe "creating a message" do
+    test "success" do
+      %{
+        user_challenge_owner: user_challenge_owner,
+        user_solver: user_solver,
+        message_context: message_context
+      } = create_message_context_status()
+
+      {:ok, challenge_owner_context} =
+        MessageContextStatuses.get(user_challenge_owner, message_context)
+
+      {:ok, solver_context} = MessageContextStatuses.get(user_solver, message_context)
+
+      {:ok, solver_context} = MessageContextStatuses.toggle_read(solver_context)
+
+      refute challenge_owner_context.read
+      assert solver_context.read
+
+      {:ok, message} =
+        Messages.create(user_challenge_owner, message_context, %{
+          "content" => "Test",
+          "content_delta" => "Test"
+        })
+
+      {:ok, challenge_owner_context} =
+        MessageContextStatuses.get(user_challenge_owner, message_context)
+
+      {:ok, solver_context} = MessageContextStatuses.get(user_solver, message_context)
+
+      assert challenge_owner_context.read
+      refute solver_context.read
+
+      assert message.author_id == user_challenge_owner.id
+      assert message.message_context_id == message_context.id
+      assert message.content == "Test"
+      assert message.content == "Test"
+      assert message.content_delta == "Test"
+    end
+  end
 end

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -131,4 +131,26 @@ defmodule ChallengeGov.TestHelpers do
 
     timestamp
   end
+
+  def convert_date_format(date) do
+    date
+    |> DateTime.to_string()
+    |> String.replace(" ", "T")
+  end
+
+  def convert_atoms_to_strings(data) do
+    data
+    |> Enum.reduce([], fn winner, acc ->
+      acc ++
+        [
+          Map.new(winner, fn {key, value} ->
+            if key in [:inserted_at, :updated_at] do
+              {Atom.to_string(key), convert_date_format(value)}
+            else
+              {Atom.to_string(key), value}
+            end
+          end)
+        ]
+    end)
+  end
 end

--- a/test/support/test_helpers/message_context_status_helpers.ex
+++ b/test/support/test_helpers/message_context_status_helpers.ex
@@ -1,0 +1,63 @@
+defmodule ChallengeGov.TestHelpers.MessageContextStatusHelpers do
+  @moduledoc """
+  Helper factory functions for message context statuses
+  """
+
+  alias ChallengeGov.Challenges
+  alias ChallengeGov.Repo
+
+  alias ChallengeGov.TestHelpers.AccountHelpers
+  alias ChallengeGov.TestHelpers.ChallengeHelpers
+  alias ChallengeGov.TestHelpers.SubmissionHelpers
+
+  alias ChallengeGov.MessageContexts
+  alias ChallengeGov.MessageContextStatuses
+
+  @challenge_owner_params %{
+    email: "challenge_owner@example.com",
+    role: "challenge_owner"
+  }
+
+  @solver_params %{
+    email: "solver_1@example.com",
+    role: "solver"
+  }
+
+  def create_message_context_status() do
+    user_challenge_owner = AccountHelpers.create_user(@challenge_owner_params)
+    user_solver = AccountHelpers.create_user(@solver_params)
+
+    challenge =
+      ChallengeHelpers.create_single_phase_challenge(user_challenge_owner, %{
+        user_id: user_challenge_owner.id
+      })
+
+    {:ok, message_context} =
+      MessageContexts.create(%{
+        "context" => "challenge",
+        "context_id" => challenge.id,
+        "audience" => ["solvers"]
+      })
+
+    message_context = Repo.preload(message_context, [:statuses])
+
+    _submission = SubmissionHelpers.create_submitted_submission(%{}, user_solver, challenge)
+
+    {:ok, challenge_owner_message_context_status} =
+      MessageContextStatuses.get(user_challenge_owner, message_context)
+
+    {:ok, solver_message_context_status} =
+      MessageContextStatuses.create(user_solver, message_context)
+
+    message_context = Repo.preload(message_context, [:statuses], force: true)
+
+    %{
+      challenge: challenge,
+      message_context: message_context,
+      challenge_owner_message_context_status: challenge_owner_message_context_status,
+      solver_message_context_status: solver_message_context_status,
+      user_challenge_owner: user_challenge_owner,
+      user_solver: user_solver
+    }
+  end
+end

--- a/test/support/test_helpers/submission_helpers.ex
+++ b/test/support/test_helpers/submission_helpers.ex
@@ -12,9 +12,7 @@ defmodule ChallengeGov.TestHelpers.SubmissionHelpers do
         "title" => "Test Title",
         "brief_description" => "Test Brief Description",
         "description" => "Test Description",
-        "external_url" => "www.example.com",
-        "terms_accepted" => "true",
-        "review_verified" => "true"
+        "external_url" => "www.example.com"
       },
       attributes
     )

--- a/test/web/controllers/api/challenge_controller_test.exs
+++ b/test/web/controllers/api/challenge_controller_test.exs
@@ -9,7 +9,6 @@ defmodule Web.Api.ChallengeControllerTest do
   alias ChallengeGov.TestHelpers.AccountHelpers
   alias ChallengeGov.TestHelpers.AgencyHelpers
   alias ChallengeGov.TestHelpers.ChallengeHelpers
-  alias ChallengeGov.TestHelpers
 
   describe "retrieving JSON list of published challenges" do
     test "successfully", %{conn: conn} do
@@ -186,7 +185,7 @@ defmodule Web.Api.ChallengeControllerTest do
         }
       )
 
-      submission = Repo.preload(submission, [phase: [winners: [:winners]]], force: true)
+      Repo.preload(submission, [phase: [winners: [:winners]]], force: true)
 
       conn = get(conn, Routes.api_challenge_path(conn, :show, challenge.id))
       phase = List.first(json_response(conn, 200)["phases"])

--- a/test/web/controllers/api/winner_controller_test.exs
+++ b/test/web/controllers/api/winner_controller_test.exs
@@ -1,0 +1,92 @@
+defmodule Web.Api.WinnerControllerTest do
+  use Web.ConnCase
+  use Web, :view
+
+  alias ChallengeGov.Repo
+  alias ChallengeGov.TestHelpers.AccountHelpers
+  alias ChallengeGov.TestHelpers.ChallengeHelpers
+  alias ChallengeGov.TestHelpers.SubmissionHelpers
+  alias ChallengeGov.PhaseWinners
+  alias ChallengeGov.TestHelpers
+
+  describe "retrieving JSON list of winners" do
+    test "successfully with winners", %{conn: conn} do
+      user = AccountHelpers.create_user()
+
+      challenge =
+        ChallengeHelpers.create_single_phase_challenge(user, %{
+          user_id: user.id,
+          title: "Test Title 1",
+          status: "published"
+        })
+
+      submission = SubmissionHelpers.create_submitted_submission(%{}, user, challenge)
+
+      submission = Repo.preload(submission, phase: [:winners])
+
+      {:ok, phase_winner} = PhaseWinners.create(submission.phase)
+
+      PhaseWinners.update(
+        phase_winner,
+        %{
+          "phase_winner" => %{
+            "overview" => "",
+            "overview_delta" => "",
+            "overview_image_path" => "",
+            "winners" => %{
+              "0" => %{
+                "id" => "",
+                "image_path" => "",
+                "name" => "Jane Doe",
+                "place_title" => "1st",
+                "remove" => "false"
+              }
+            }
+          }
+        }
+      )
+
+      submission = Repo.preload(submission, [phase: [winners: [:winners]]], force: true)
+
+      expected_json = expected_show_json(submission.phase.winners, submission.phase.title)
+
+      conn = get(conn, Routes.api_winner_path(conn, :phase_winners, submission.phase_id))
+      assert json_response(conn, 200) === expected_json
+    end
+
+    test "successfully with no winners", %{conn: conn} do
+      user = AccountHelpers.create_user()
+
+      challenge =
+        ChallengeHelpers.create_single_phase_challenge(user, %{
+          user_id: user.id,
+          title: "Test Title 1",
+          status: "published"
+        })
+
+      submission = SubmissionHelpers.create_submitted_submission(%{}, user, challenge)
+
+      conn = get(conn, Routes.api_winner_path(conn, :phase_winners, submission.phase_id))
+      assert json_response(conn, 200) === %{}
+    end
+  end
+
+  defp expected_show_json(phase_winner, phase_title) do
+    %{
+      "id" => phase_winner.id,
+      "inserted_at" => TestHelpers.convert_date_format(phase_winner.inserted_at),
+      "overview" => phase_winner.overview,
+      "overview_delta" => phase_winner.overview_delta,
+      "overview_image_path" => phase_winner.overview_image_path,
+      "phase_title" => phase_title,
+      "phase_id" => phase_winner.phase_id,
+      "status" => phase_winner.status,
+      "updated_at" => TestHelpers.convert_date_format(phase_winner.updated_at),
+      "uuid" => phase_winner.uuid,
+      "winners" =>
+        TestHelpers.convert_atoms_to_strings(
+          render_many(phase_winner.winners, Web.Api.WinnerView, "winners.json")
+        )
+    }
+  end
+end

--- a/test/web/controllers/challenge_controller_test.exs
+++ b/test/web/controllers/challenge_controller_test.exs
@@ -191,8 +191,348 @@ defmodule Web.ChallengeControllerTest do
     end
   end
 
+  describe "edit for challenges" do
+    test "successfully", %{conn: conn} do
+      conn = prep_conn(conn)
+      %{current_user: user} = conn.assigns
+
+      challenge = ChallengeHelpers.create_challenge(%{user_id: user.id, status: "draft"})
+
+      conn = get(conn, Routes.challenge_path(conn, :edit, challenge.id, "general"))
+
+      %{
+        user: user_in_assigns,
+        challenge: challenge_in_assigns,
+        changeset: changeset,
+        section: section
+      } = conn.assigns
+
+      assert user === user_in_assigns
+      assert challenge.id === challenge_in_assigns.id
+      assert changeset === Challenges.edit(challenge_in_assigns)
+      assert section === "general"
+
+      assert conn.request_path ===
+               Routes.challenge_path(conn, :edit, challenge_in_assigns, "general")
+
+      assert html_response(conn, 200) =~ "Challenge"
+    end
+
+    test "successfully edit a challenge in review as a Challenge Owner", %{conn: conn} do
+      conn = prep_conn_challenge_owner(conn)
+      %{current_user: challenge_owner} = conn.assigns
+
+      challenge =
+        ChallengeHelpers.create_challenge(
+          %{user_id: challenge_owner.id, status: "gsa_review", title: "Who's Line is it Anyway?"},
+          challenge_owner
+        )
+
+      conn = get(conn, Routes.challenge_path(conn, :edit, challenge.id, "general"))
+
+      %{
+        current_user: user_in_assigns,
+        challenge: challenge_in_assigns,
+        section: section
+      } = conn.assigns
+
+      assert challenge_owner === user_in_assigns
+      assert challenge.id === challenge_in_assigns.id
+      assert html_response(conn, 200) =~ "Challenge"
+      assert challenge_in_assigns.status === "draft"
+      assert section === "general"
+
+      assert conn.request_path ===
+               Routes.challenge_path(conn, :edit, challenge_in_assigns, "general")
+
+      assert get_flash(conn, :warning) ===
+               [
+                 {:safe,
+                  [
+                    60,
+                    "span",
+                    [[32, "class", 61, 34, "h4", 34]],
+                    62,
+                    "Challenge Removed from Queue",
+                    60,
+                    47,
+                    "span",
+                    62
+                  ]},
+                 {:safe, [60, "br", [], 62, [], 60, 47, "br", 62]},
+                 "Once edits are made you will need to resubmit this challenge for GSA approval"
+               ]
+    end
+
+    test "successfully edit a challenge in review as an admin", %{conn: conn} do
+      conn = prep_conn(conn)
+      %{current_user: user} = conn.assigns
+
+      challenge =
+        ChallengeHelpers.create_challenge(
+          %{user_id: user.id, status: "gsa_review", title: "Who's Line is it Anyway?"},
+          user
+        )
+
+      conn = get(conn, Routes.challenge_path(conn, :edit, challenge.id, "general"))
+
+      %{
+        current_user: user_in_assigns,
+        challenge: challenge_in_assigns,
+        changeset: changeset,
+        section: section
+      } = conn.assigns
+
+      assert user === user_in_assigns
+      assert challenge.id === challenge_in_assigns.id
+      assert html_response(conn, 200) =~ "Challenge"
+      assert changeset === Challenges.edit(challenge_in_assigns)
+      assert section === "general"
+
+      assert conn.request_path ===
+               Routes.challenge_path(conn, :edit, challenge_in_assigns, "general")
+
+      assert challenge_in_assigns.status === "gsa_review"
+    end
+
+    test "successfully edit a published challenge", %{conn: conn} do
+      conn = prep_conn(conn)
+      %{current_user: user} = conn.assigns
+
+      challenge =
+        ChallengeHelpers.create_challenge(
+          %{user_id: user.id, status: "published", title: "Who's Line is it Anyway?"},
+          user
+        )
+
+      conn = get(conn, Routes.challenge_path(conn, :edit, challenge.id, "general"))
+
+      %{
+        current_user: user_in_assigns,
+        challenge: challenge_in_assigns,
+        changeset: changeset,
+        section: section
+      } = conn.assigns
+
+      assert user === user_in_assigns
+      assert challenge.id === challenge_in_assigns.id
+      assert changeset === Challenges.edit(challenge_in_assigns)
+      assert html_response(conn, 200) =~ "Challenge"
+      assert section === "general"
+
+      assert conn.request_path ===
+               Routes.challenge_path(conn, :edit, challenge_in_assigns, "general")
+
+      assert challenge_in_assigns.status === "published"
+    end
+  end
+
+  describe "update for challenges" do
+    test "successfully update a section as a draft", %{conn: conn} do
+      conn = prep_conn(conn)
+      %{current_user: user} = conn.assigns
+
+      challenge = ChallengeHelpers.create_challenge(%{user_id: user.id, status: "draft"})
+
+      params = %{
+        "id" => "#{challenge.id}",
+        "action" => "save_draft",
+        "challenge" => %{
+          "section" => "general",
+          "agency_id" => AgencyHelpers.create_agency().id,
+          "challenge_id" => "#{challenge.id}",
+          "challenge_manager" => "Challenge Manager",
+          "challenge_manager_email" => "challenge_owner_active@example.com",
+          "federal_partners" => %{
+            "0" => %{
+              "agency_id" => AgencyHelpers.create_agency().id,
+              "sub_agency_id" => AgencyHelpers.create_agency().id
+            }
+          },
+          "fiscal_year" => "FY20",
+          "local_timezone" => "America/New_York",
+          "non_federal_partners" => %{
+            "0" => %{"id" => "1", "name" => "Non federal partner 1"},
+            "1" => %{"id" => "2", "name" => "Non federal partner 2"}
+          },
+          "poc_email" => "new_poc@example.com",
+          "sub_agency_id" => AgencyHelpers.create_agency().id,
+          "user_id" => "#{user.id}"
+        }
+      }
+
+      conn = put(conn, Routes.challenge_path(conn, :update, challenge.id), params)
+
+      {:ok, challenge} = Challenges.get(challenge.id)
+
+      assert challenge.status === "draft"
+      assert challenge.poc_email === "new_poc@example.com"
+      assert get_flash(conn, :info) === "Challenge saved as draft"
+      assert redirected_to(conn) === Routes.challenge_path(conn, :edit, challenge.id, "general")
+    end
+
+    test "successfully update a section and return to review", %{conn: conn} do
+      conn = prep_conn(conn)
+      %{current_user: user} = conn.assigns
+
+      challenge = ChallengeHelpers.create_challenge(%{user_id: user.id, status: "draft"})
+
+      params = %{
+        "id" => "#{challenge.id}",
+        "action" => "return_to_review",
+        "challenge" => %{
+          "section" => "general",
+          "agency_id" => AgencyHelpers.create_agency().id,
+          "challenge_id" => "#{challenge.id}",
+          "challenge_manager" => "Challenge Manager",
+          "challenge_manager_email" => "challenge_owner_active@example.com",
+          "federal_partners" => %{
+            "0" => %{
+              "agency_id" => AgencyHelpers.create_agency().id,
+              "sub_agency_id" => AgencyHelpers.create_agency().id
+            }
+          },
+          "fiscal_year" => "FY20",
+          "local_timezone" => "America/New_York",
+          "non_federal_partners" => %{
+            "0" => %{"id" => "1", "name" => "Non federal partner 1"},
+            "1" => %{"id" => "2", "name" => "Non federal partner 2"}
+          },
+          "poc_email" => "new_poc@example.com",
+          "sub_agency_id" => AgencyHelpers.create_agency().id,
+          "user_id" => "#{user.id}"
+        }
+      }
+
+      conn = put(conn, Routes.challenge_path(conn, :update, challenge.id), params)
+
+      {:ok, challenge} = Challenges.get(challenge.id)
+
+      assert challenge.status === "draft"
+      assert challenge.poc_email === "new_poc@example.com"
+      assert get_flash(conn, :info) === "changes saved"
+
+      assert redirected_to(conn) ===
+               Routes.challenge_path(conn, :show, challenge.id) <> "#general"
+    end
+
+    test "successfully update a section and go to next section", %{conn: conn} do
+      conn = prep_conn(conn)
+      %{current_user: user} = conn.assigns
+
+      challenge = ChallengeHelpers.create_challenge(%{user_id: user.id, status: "draft"})
+
+      params = %{
+        "id" => "#{challenge.id}",
+        "action" => "next",
+        "challenge" => %{
+          "section" => "general",
+          "agency_id" => AgencyHelpers.create_agency().id,
+          "challenge_id" => "#{challenge.id}",
+          "challenge_manager" => "Challenge Manager",
+          "challenge_manager_email" => "challenge_owner_active@example.com",
+          "federal_partners" => %{
+            "0" => %{
+              "agency_id" => AgencyHelpers.create_agency().id,
+              "sub_agency_id" => AgencyHelpers.create_agency().id
+            }
+          },
+          "fiscal_year" => "FY20",
+          "local_timezone" => "America/New_York",
+          "non_federal_partners" => %{
+            "0" => %{"id" => "1", "name" => "Non federal partner 1"},
+            "1" => %{"id" => "2", "name" => "Non federal partner 2"}
+          },
+          "poc_email" => "new_poc@example.com",
+          "sub_agency_id" => AgencyHelpers.create_agency().id,
+          "user_id" => "#{user.id}"
+        }
+      }
+
+      conn = put(conn, Routes.challenge_path(conn, :update, challenge.id), params)
+
+      {:ok, challenge} = Challenges.get(challenge.id)
+
+      to_section = Challenges.to_section("general", "next")
+
+      assert challenge.status === "draft"
+      assert challenge.poc_email === "new_poc@example.com"
+
+      assert redirected_to(conn) ===
+               Routes.challenge_path(conn, :edit, challenge.id, to_section.id)
+    end
+
+    test "successfully update a published challenge", %{conn: conn} do
+      # change something
+      # return to review
+      # still published
+      conn = prep_conn_challenge_owner(conn)
+      %{current_user: user} = conn.assigns
+
+      past_publish_date =
+        DateTime.utc_now()
+        |> Timex.shift(days: -1)
+        |> DateTime.to_string()
+
+      challenge =
+        ChallengeHelpers.create_challenge(
+          %{
+            user_id: user.id,
+            status: "published",
+            auto_publish_date: past_publish_date
+          },
+          user
+        )
+
+      params = %{
+        "id" => "#{challenge.id}",
+        "action" => "return_to_review",
+        "challenge" => %{
+          "section" => "general",
+          "agency_id" => AgencyHelpers.create_agency().id,
+          "challenge_id" => "#{challenge.id}",
+          "challenge_manager" => "Challenge Manager",
+          "challenge_manager_email" => "challenge_owner_active@example.com",
+          "federal_partners" => %{
+            "0" => %{
+              "agency_id" => AgencyHelpers.create_agency().id,
+              "sub_agency_id" => AgencyHelpers.create_agency().id
+            }
+          },
+          "fiscal_year" => "FY20",
+          "local_timezone" => "America/New_York",
+          "non_federal_partners" => %{
+            "0" => %{"id" => "1", "name" => "Non federal partner 1"},
+            "1" => %{"id" => "2", "name" => "Non federal partner 2"}
+          },
+          "poc_email" => "new_poc@example.com",
+          "sub_agency_id" => AgencyHelpers.create_agency().id,
+          "user_id" => "#{user.id}"
+        }
+      }
+
+      conn = put(conn, Routes.challenge_path(conn, :update, challenge.id), params)
+
+      {:ok, challenge} = Challenges.get(challenge.id)
+
+      assert challenge.status === "published"
+      assert challenge.poc_email === "new_poc@example.com"
+      assert get_flash(conn, :info) === "changes saved"
+
+      assert redirected_to(conn) ===
+               Routes.challenge_path(conn, :show, challenge.id) <> "#general"
+    end
+  end
+
   defp prep_conn(conn) do
     user = AccountHelpers.create_user(%{role: "admin"})
+    assign(conn, :current_user, user)
+  end
+
+  defp prep_conn_challenge_owner(conn) do
+    user =
+      AccountHelpers.create_user(%{email: "challenge_owner@example.com", role: "challenge_owner"})
+
     assign(conn, :current_user, user)
   end
 

--- a/test/web/controllers/challenge_controller_test.exs
+++ b/test/web/controllers/challenge_controller_test.exs
@@ -218,14 +218,14 @@ defmodule Web.ChallengeControllerTest do
       assert html_response(conn, 200) =~ "Challenge"
     end
 
-    test "successfully edit a challenge in review as a Challenge Owner", %{conn: conn} do
-      conn = prep_conn_challenge_owner(conn)
-      %{current_user: challenge_owner} = conn.assigns
+    test "successfully edit a challenge in review", %{conn: conn} do
+      conn = prep_conn(conn)
+      %{current_user: user} = conn.assigns
 
       challenge =
         ChallengeHelpers.create_challenge(
-          %{user_id: challenge_owner.id, status: "gsa_review", title: "Who's Line is it Anyway?"},
-          challenge_owner
+          %{user_id: user.id, status: "gsa_review", title: "Who's Line is it Anyway?"},
+          user
         )
 
       conn = get(conn, Routes.challenge_path(conn, :edit, challenge.id, "general"))
@@ -236,7 +236,7 @@ defmodule Web.ChallengeControllerTest do
         section: section
       } = conn.assigns
 
-      assert challenge_owner === user_in_assigns
+      assert user === user_in_assigns
       assert challenge.id === challenge_in_assigns.id
       assert html_response(conn, 200) =~ "Challenge"
       assert challenge_in_assigns.status === "draft"
@@ -262,37 +262,6 @@ defmodule Web.ChallengeControllerTest do
                  {:safe, [60, "br", [], 62, [], 60, 47, "br", 62]},
                  "Once edits are made you will need to resubmit this challenge for GSA approval"
                ]
-    end
-
-    test "successfully edit a challenge in review as an admin", %{conn: conn} do
-      conn = prep_conn(conn)
-      %{current_user: user} = conn.assigns
-
-      challenge =
-        ChallengeHelpers.create_challenge(
-          %{user_id: user.id, status: "gsa_review", title: "Who's Line is it Anyway?"},
-          user
-        )
-
-      conn = get(conn, Routes.challenge_path(conn, :edit, challenge.id, "general"))
-
-      %{
-        current_user: user_in_assigns,
-        challenge: challenge_in_assigns,
-        changeset: changeset,
-        section: section
-      } = conn.assigns
-
-      assert user === user_in_assigns
-      assert challenge.id === challenge_in_assigns.id
-      assert html_response(conn, 200) =~ "Challenge"
-      assert changeset === Challenges.edit(challenge_in_assigns)
-      assert section === "general"
-
-      assert conn.request_path ===
-               Routes.challenge_path(conn, :edit, challenge_in_assigns, "general")
-
-      assert challenge_in_assigns.status === "gsa_review"
     end
 
     test "successfully edit a published challenge", %{conn: conn} do

--- a/test/web/controllers/message_context_controller_test.exs
+++ b/test/web/controllers/message_context_controller_test.exs
@@ -1,0 +1,224 @@
+defmodule Web.MessageContextControllerTest do
+  use Web.ConnCase
+
+  alias ChallengeGov.MessageContextStatuses
+  alias ChallengeGov.TestHelpers.MessageContextStatusHelpers
+
+  defp prep_conn(conn, user) do
+    assign(conn, :current_user, user)
+  end
+
+  describe "filter starred" do
+    test "success", %{conn: conn} do
+      %{
+        challenge_owner_message_context_status: challenge_owner_message_context_status,
+        user_challenge_owner: user_challenge_owner
+      } = MessageContextStatusHelpers.create_message_context_status()
+
+      conn = prep_conn(conn, user_challenge_owner)
+
+      {:ok, _message_context_status} =
+        MessageContextStatuses.toggle_starred(challenge_owner_message_context_status)
+
+      conn =
+        get(
+          conn,
+          Routes.message_context_path(
+            conn,
+            :index,
+            filter: %{"starred" => true}
+          )
+        )
+
+      %{message_context_statuses: message_context_statuses} = conn.assigns
+
+      assert length(message_context_statuses) == 1
+
+      assert html_response(conn, 200)
+    end
+
+    test "success: none", %{conn: conn} do
+      %{
+        user_challenge_owner: user_challenge_owner
+      } = MessageContextStatusHelpers.create_message_context_status()
+
+      conn = prep_conn(conn, user_challenge_owner)
+
+      conn =
+        get(
+          conn,
+          Routes.message_context_path(
+            conn,
+            :index,
+            filter: %{"starred" => true}
+          )
+        )
+
+      %{message_context_statuses: message_context_statuses} = conn.assigns
+
+      assert Enum.empty?(message_context_statuses)
+
+      assert html_response(conn, 200)
+    end
+  end
+
+  describe "filter archived" do
+    test "success", %{conn: conn} do
+      %{
+        challenge_owner_message_context_status: challenge_owner_message_context_status,
+        user_challenge_owner: user_challenge_owner
+      } = MessageContextStatusHelpers.create_message_context_status()
+
+      conn = prep_conn(conn, user_challenge_owner)
+
+      {:ok, _message_context_status} =
+        MessageContextStatuses.toggle_archived(challenge_owner_message_context_status)
+
+      conn =
+        get(
+          conn,
+          Routes.message_context_path(
+            conn,
+            :index,
+            filter: %{"archived" => true}
+          )
+        )
+
+      %{message_context_statuses: message_context_statuses} = conn.assigns
+
+      assert length(message_context_statuses) == 1
+
+      assert html_response(conn, 200)
+    end
+
+    test "success: none", %{conn: conn} do
+      %{
+        user_challenge_owner: user_challenge_owner
+      } = MessageContextStatusHelpers.create_message_context_status()
+
+      conn = prep_conn(conn, user_challenge_owner)
+
+      conn =
+        get(
+          conn,
+          Routes.message_context_path(
+            conn,
+            :index,
+            filter: %{"archived" => true}
+          )
+        )
+
+      %{message_context_statuses: message_context_statuses} = conn.assigns
+
+      assert Enum.empty?(message_context_statuses)
+
+      assert html_response(conn, 200)
+    end
+  end
+
+  describe "filter read" do
+    test "success", %{conn: conn} do
+      %{
+        challenge_owner_message_context_status: challenge_owner_message_context_status,
+        user_challenge_owner: user_challenge_owner
+      } = MessageContextStatusHelpers.create_message_context_status()
+
+      conn = prep_conn(conn, user_challenge_owner)
+
+      {:ok, _message_context_status} =
+        MessageContextStatuses.toggle_read(challenge_owner_message_context_status)
+
+      conn =
+        get(
+          conn,
+          Routes.message_context_path(
+            conn,
+            :index,
+            filter: %{"read" => true}
+          )
+        )
+
+      %{message_context_statuses: message_context_statuses} = conn.assigns
+
+      assert length(message_context_statuses) == 1
+
+      assert html_response(conn, 200)
+    end
+
+    test "success: none", %{conn: conn} do
+      %{
+        user_challenge_owner: user_challenge_owner
+      } = MessageContextStatusHelpers.create_message_context_status()
+
+      conn = prep_conn(conn, user_challenge_owner)
+
+      conn =
+        get(
+          conn,
+          Routes.message_context_path(
+            conn,
+            :index,
+            filter: %{"read" => true}
+          )
+        )
+
+      %{message_context_statuses: message_context_statuses} = conn.assigns
+
+      assert Enum.empty?(message_context_statuses)
+
+      assert html_response(conn, 200)
+    end
+  end
+
+  describe "filter by challenge" do
+    test "success", %{conn: conn} do
+      %{
+        challenge: challenge,
+        user_challenge_owner: user_challenge_owner
+      } = MessageContextStatusHelpers.create_message_context_status()
+
+      conn = prep_conn(conn, user_challenge_owner)
+
+      conn =
+        get(
+          conn,
+          Routes.message_context_path(
+            conn,
+            :index,
+            filter: %{"challenge_id" => challenge.id}
+          )
+        )
+
+      %{message_context_statuses: message_context_statuses} = conn.assigns
+
+      assert length(message_context_statuses) == 1
+
+      assert html_response(conn, 200)
+    end
+
+    test "success: none", %{conn: conn} do
+      %{
+        challenge: challenge,
+        user_challenge_owner: user_challenge_owner
+      } = MessageContextStatusHelpers.create_message_context_status()
+
+      conn = prep_conn(conn, user_challenge_owner)
+
+      conn =
+        get(
+          conn,
+          Routes.message_context_path(
+            conn,
+            :index,
+            filter: %{"challenge_id" => challenge.id + 1}
+          )
+        )
+
+      %{message_context_statuses: message_context_statuses} = conn.assigns
+
+      assert Enum.empty?(message_context_statuses)
+
+      assert html_response(conn, 200)
+    end
+  end
+end

--- a/test/web/controllers/message_context_status_controller_test.exs
+++ b/test/web/controllers/message_context_status_controller_test.exs
@@ -1,0 +1,105 @@
+defmodule Web.MessageContextStatusControllerTest do
+  use Web.ConnCase
+
+  alias ChallengeGov.TestHelpers.MessageContextStatusHelpers
+
+  defp prep_conn(conn, user) do
+    assign(conn, :current_user, user)
+  end
+
+  describe "mark read" do
+    test "success", %{conn: conn} do
+      %{
+        challenge_owner_message_context_status: challenge_owner_message_context_status,
+        user_challenge_owner: user_challenge_owner
+      } = MessageContextStatusHelpers.create_message_context_status()
+
+      conn = prep_conn(conn, user_challenge_owner)
+
+      conn =
+        post(
+          conn,
+          Routes.message_context_status_path(
+            conn,
+            :mark_read,
+            challenge_owner_message_context_status.id
+          )
+        )
+
+      assert get_flash(conn, :info) == "Message thread marked as read"
+      assert html_response(conn, 302)
+    end
+  end
+
+  describe "mark unread" do
+    test "success", %{conn: conn} do
+      %{
+        challenge_owner_message_context_status: challenge_owner_message_context_status,
+        user_challenge_owner: user_challenge_owner
+      } = MessageContextStatusHelpers.create_message_context_status()
+
+      conn = prep_conn(conn, user_challenge_owner)
+
+      conn =
+        post(
+          conn,
+          Routes.message_context_status_path(
+            conn,
+            :mark_unread,
+            challenge_owner_message_context_status.id
+          )
+        )
+
+      assert get_flash(conn, :info) == "Message thread marked as unread"
+      assert html_response(conn, 302)
+    end
+  end
+
+  describe "archive" do
+    test "success", %{conn: conn} do
+      %{
+        challenge_owner_message_context_status: challenge_owner_message_context_status,
+        user_challenge_owner: user_challenge_owner
+      } = MessageContextStatusHelpers.create_message_context_status()
+
+      conn = prep_conn(conn, user_challenge_owner)
+
+      conn =
+        post(
+          conn,
+          Routes.message_context_status_path(
+            conn,
+            :archive,
+            challenge_owner_message_context_status.id
+          )
+        )
+
+      assert get_flash(conn, :info) == "Message thread archived"
+      assert html_response(conn, 302)
+    end
+  end
+
+  describe "unarchive" do
+    test "success", %{conn: conn} do
+      %{
+        challenge_owner_message_context_status: challenge_owner_message_context_status,
+        user_challenge_owner: user_challenge_owner
+      } = MessageContextStatusHelpers.create_message_context_status()
+
+      conn = prep_conn(conn, user_challenge_owner)
+
+      conn =
+        post(
+          conn,
+          Routes.message_context_status_path(
+            conn,
+            :unarchive,
+            challenge_owner_message_context_status.id
+          )
+        )
+
+      assert get_flash(conn, :info) == "Message thread unarchived"
+      assert html_response(conn, 302)
+    end
+  end
+end

--- a/test/web/controllers/submission_controller_test.exs
+++ b/test/web/controllers/submission_controller_test.exs
@@ -270,7 +270,7 @@ defmodule Web.SubmissionControllerTest do
   end
 
   describe "create action" do
-    test "saving as a draft", %{conn: conn} do
+    test "saving as a draft as a solver", %{conn: conn} do
       conn = prep_conn(conn)
       %{current_user: user} = conn.assigns
 
@@ -292,7 +292,32 @@ defmodule Web.SubmissionControllerTest do
       assert redirected_to(conn) === Routes.submission_path(conn, :edit, id)
     end
 
-    test "creating a submission and review", %{conn: conn} do
+    test "saving as a draft as an admin", %{conn: conn} do
+      conn = prep_conn_admin(conn)
+      %{current_user: user} = conn.assigns
+
+      solver_user = AccountHelpers.create_user(%{email: "solver@example.com", role: "solver"})
+
+      challenge = ChallengeHelpers.create_single_phase_challenge(user, %{user_id: user.id})
+      phase = challenge.phases |> Enum.at(0)
+
+      params = %{
+        "action" => "draft",
+        "submission" => %{
+          "solver_addr" => solver_user.email,
+          "title" => "Test title"
+        },
+        "challenge_id" => challenge.id,
+        "phase_id" => "#{phase.id}"
+      }
+
+      conn = post(conn, Routes.challenge_submission_path(conn, :create, challenge.id), params)
+
+      assert %{id: id} = redirected_params(conn)
+      assert redirected_to(conn) === Routes.submission_path(conn, :edit, id)
+    end
+
+    test "creating a submission and review as a solver", %{conn: conn} do
       conn = prep_conn(conn)
       %{current_user: user} = conn.assigns
 
@@ -308,6 +333,34 @@ defmodule Web.SubmissionControllerTest do
           "external_url" => "Test external url",
           "terms_accepted" => "true",
           "review_verified" => "true"
+        },
+        "challenge_id" => challenge.id,
+        "phase_id" => "#{phase.id}"
+      }
+
+      conn = post(conn, Routes.challenge_submission_path(conn, :create, challenge.id), params)
+
+      assert %{id: id} = redirected_params(conn)
+      assert redirected_to(conn) === Routes.submission_path(conn, :show, id)
+    end
+
+    test "creating a submission and review as an admin", %{conn: conn} do
+      conn = prep_conn_admin(conn)
+      %{current_user: user} = conn.assigns
+
+      solver_user = AccountHelpers.create_user(%{email: "solver@example.com", role: "solver"})
+
+      challenge = ChallengeHelpers.create_single_phase_challenge(user, %{user_id: user.id})
+      phase = challenge.phases |> Enum.at(0)
+
+      params = %{
+        "action" => "review",
+        "submission" => %{
+          "solver_addr" => solver_user.email,
+          "title" => "Test title",
+          "brief_description" => "Test brief description",
+          "description" => "Test description",
+          "external_url" => "Test external url"
         },
         "challenge_id" => challenge.id,
         "phase_id" => "#{phase.id}"
@@ -341,6 +394,34 @@ defmodule Web.SubmissionControllerTest do
       assert changeset.errors[:title]
       assert changeset.errors[:brief_description]
       assert changeset.errors[:description]
+    end
+
+    test "creating a submission and review as a challenge owner", %{conn: conn} do
+      conn = prep_conn_challenge_owner(conn)
+
+      admin_user = AccountHelpers.create_user(%{email: "admin_user_2@example.com", role: "admin"})
+
+      challenge =
+        ChallengeHelpers.create_single_phase_challenge(admin_user, %{user_id: admin_user.id})
+
+      phase = challenge.phases |> Enum.at(0)
+
+      params = %{
+        "action" => "review",
+        "submission" => %{
+          "title" => "Test title",
+          "brief_description" => "Test brief description",
+          "description" => "Test description",
+          "external_url" => "Test external url"
+        },
+        "challenge_id" => challenge.id,
+        "phase_id" => "#{phase.id}"
+      }
+
+      conn = post(conn, Routes.challenge_submission_path(conn, :create, challenge.id), params)
+
+      assert get_flash(conn, :error) === "You are not authorized"
+      assert redirected_to(conn) === Routes.dashboard_path(conn, :index)
     end
   end
 
@@ -392,10 +473,92 @@ defmodule Web.SubmissionControllerTest do
       assert get_flash(conn, :error) === "You are not authorized to edit this submission"
       assert redirected_to(conn) === Routes.submission_path(conn, :index)
     end
+
+    test "failure: viewing the edit submission form for a solver created submission as an admin",
+         %{conn: conn} do
+      conn = prep_conn_admin(conn)
+      solver_user = AccountHelpers.create_user(%{email: "solver@example.com", role: "solver"})
+
+      challenge =
+        ChallengeHelpers.create_single_phase_challenge(solver_user, %{user_id: solver_user.id})
+
+      submission =
+        SubmissionHelpers.create_submitted_submission(
+          %{
+            "terms_accepted" => "true",
+            "review_verified" => "true"
+          },
+          solver_user,
+          challenge
+        )
+
+      conn = get(conn, Routes.submission_path(conn, :edit, submission.id))
+
+      assert get_flash(conn, :error) === "You are not authorized to edit this submission"
+
+      assert redirected_to(conn) ===
+               Routes.challenge_phase_managed_submission_path(
+                 conn,
+                 :managed_submissions,
+                 submission.challenge_id,
+                 submission.phase_id
+               )
+    end
+
+    test "failure: viewing the edit submission form for an admin created submission that's been verified as an admin",
+         %{conn: conn} do
+      conn = prep_conn_admin(conn)
+      %{current_user: admin_user} = conn.assigns
+      solver_user = AccountHelpers.create_user(%{email: "solver@example.com", role: "solver"})
+
+      challenge =
+        ChallengeHelpers.create_single_phase_challenge(solver_user, %{user_id: solver_user.id})
+
+      submission =
+        SubmissionHelpers.create_submitted_submission(
+          %{
+            "manager_id" => admin_user.id,
+            "terms_accepted" => "true",
+            "review_verified" => "true"
+          },
+          solver_user,
+          challenge
+        )
+
+      conn = get(conn, Routes.submission_path(conn, :edit, submission.id))
+
+      assert get_flash(conn, :error) === "Submission cannot be edited"
+
+      assert redirected_to(conn) ===
+               Routes.challenge_phase_managed_submission_path(
+                 conn,
+                 :managed_submissions,
+                 submission.challenge_id,
+                 submission.phase_id
+               )
+    end
+
+    test "failure: viewing the edit submission form as a Challenge Owner", %{conn: conn} do
+      conn = prep_conn_challenge_owner(conn)
+      %{current_user: challenge_owner} = conn.assigns
+      solver_user = AccountHelpers.create_user(%{email: "solver@example.com"})
+
+      challenge =
+        ChallengeHelpers.create_single_phase_challenge(challenge_owner, %{
+          user_id: challenge_owner.id
+        })
+
+      submission = SubmissionHelpers.create_submitted_submission(%{}, solver_user, challenge)
+
+      conn = get(conn, Routes.submission_path(conn, :edit, submission.id))
+
+      assert get_flash(conn, :error) === "You are not authorized"
+      assert redirected_to(conn) === Routes.dashboard_path(conn, :index)
+    end
   end
 
   describe "update action" do
-    test "updating a draft submission and saving as draft", %{conn: conn} do
+    test "updating a draft submission and saving as draft as a solver", %{conn: conn} do
       conn = prep_conn(conn)
       %{current_user: solver_user} = conn.assigns
       admin_user = AccountHelpers.create_user(%{email: "admin_user_2@example.com", role: "admin"})
@@ -413,6 +576,42 @@ defmodule Web.SubmissionControllerTest do
       params = %{
         "action" => "draft",
         "submission" => %{
+          "title" => "New test title",
+          "brief_description" => "Test brief description",
+          "description" => "Test description",
+          "external_url" => nil
+        }
+      }
+
+      conn = put(conn, Routes.submission_path(conn, :update, submission.id), params)
+
+      {:ok, submission} = Submissions.get(submission.id)
+
+      assert submission.status === "draft"
+      assert get_flash(conn, :info) === "Submission draft saved"
+      assert redirected_to(conn) === Routes.submission_path(conn, :edit, submission.id)
+    end
+
+    test "updating a draft submission and saving as draft as an admin", %{conn: conn} do
+      conn = prep_conn_admin(conn)
+      %{current_user: admin_user} = conn.assigns
+
+      solver_user = AccountHelpers.create_user(%{email: "solver@example.com", role: "solver"})
+
+      challenge =
+        ChallengeHelpers.create_single_phase_challenge(admin_user, %{user_id: admin_user.id})
+
+      submission =
+        SubmissionHelpers.create_draft_submission(
+          %{"manager_id" => admin_user.id},
+          admin_user,
+          challenge
+        )
+
+      params = %{
+        "action" => "draft",
+        "submission" => %{
+          "solver_addr" => solver_user.email,
           "title" => "New test title",
           "brief_description" => "Test brief description",
           "description" => "Test description",
@@ -493,7 +692,99 @@ defmodule Web.SubmissionControllerTest do
       assert changeset.errors[:description]
     end
 
-    test "updating a submission and sending to review", %{conn: conn} do
+    test "failure: updating a submission as a solver without accepting the terms", %{conn: conn} do
+      conn = prep_conn(conn)
+      %{current_user: user} = conn.assigns
+
+      challenge = ChallengeHelpers.create_single_phase_challenge(user, %{user_id: user.id})
+
+      submission = SubmissionHelpers.create_submitted_submission(%{}, user, challenge)
+
+      params = %{
+        "action" => "review",
+        "submission" => %{
+          "title" => "New test title",
+          "brief_description" => "Test brief description",
+          "description" => "New test description",
+          "terms_accepted" => "false"
+        }
+      }
+
+      conn = put(conn, Routes.submission_path(conn, :update, submission.id), params)
+
+      %{changeset: changeset} = conn.assigns
+
+      assert changeset.errors[:terms_accepted]
+    end
+
+    test "failure: updating an unverified submission as a solver without verifying it", %{
+      conn: conn
+    } do
+      conn = prep_conn_admin(conn)
+      %{current_user: user} = conn.assigns
+      solver_user = AccountHelpers.create_user(%{email: "solver@example.com", role: "solver"})
+
+      challenge = ChallengeHelpers.create_single_phase_challenge(user, %{user_id: user.id})
+
+      submission =
+        SubmissionHelpers.create_submitted_submission(
+          %{"manager_id" => user.id},
+          solver_user,
+          challenge
+        )
+
+      params = %{
+        "action" => "review",
+        "submission" => %{
+          "title" => "New test title",
+          "brief_description" => "Test brief description",
+          "description" => "New test description",
+          "terms_accepted" => "true",
+          "review_verified" => "false"
+        }
+      }
+
+      conn = put(conn, Routes.submission_path(conn, :update, submission.id), params)
+
+      %{changeset: changeset} = conn.assigns
+
+      assert changeset.errors[:review_verified]
+    end
+
+    test "failure: updating a verified submission as an admin", %{conn: conn} do
+      conn = prep_conn_admin(conn)
+      %{current_user: admin_user} = conn.assigns
+
+      challenge =
+        ChallengeHelpers.create_single_phase_challenge(admin_user, %{user_id: admin_user.id})
+
+      submission =
+        SubmissionHelpers.create_submitted_submission(
+          %{
+            "manager_id" => admin_user.id,
+            "terms_accepted" => "true",
+            "review_verified" => "true"
+          },
+          admin_user,
+          challenge
+        )
+
+      params = %{
+        "action" => "review",
+        "submission" => %{
+          "title" => "New test title",
+          "brief_description" => "Test brief description",
+          "description" => "New test description"
+        }
+      }
+
+      conn = put(conn, Routes.submission_path(conn, :update, submission.id), params)
+
+      assert get_flash(conn, :error) === "Submission cannot be edited"
+      assert redirected_to(conn) === Routes.submission_path(conn, :index)
+    end
+
+    test "updating a submission and sending to review as a solver", %{conn: conn} do
       conn = prep_conn(conn)
       %{current_user: user} = conn.assigns
 
@@ -510,6 +801,38 @@ defmodule Web.SubmissionControllerTest do
           "external_url" => "www.test_example.com",
           "terms_accepted" => "true",
           "review_verified" => "true"
+        }
+      }
+
+      conn = put(conn, Routes.submission_path(conn, :update, submission.id), params)
+
+      {:ok, submission} = Submissions.get(submission.id)
+
+      assert submission.status === "draft"
+      assert redirected_to(conn) === Routes.submission_path(conn, :show, submission.id)
+    end
+
+    test "updating an admin created submission and sending to review as an admin", %{conn: conn} do
+      conn = prep_conn_admin(conn)
+      %{current_user: admin_user} = conn.assigns
+
+      challenge =
+        ChallengeHelpers.create_single_phase_challenge(admin_user, %{user_id: admin_user.id})
+
+      submission =
+        SubmissionHelpers.create_submitted_submission(
+          %{"manager_id" => admin_user.id},
+          admin_user,
+          challenge
+        )
+
+      params = %{
+        "action" => "review",
+        "submission" => %{
+          "title" => "New test title",
+          "brief_description" => "New test brief description",
+          "description" => "New test description",
+          "external_url" => "www.test_example.com"
         }
       }
 
@@ -585,6 +908,34 @@ defmodule Web.SubmissionControllerTest do
 
       assert conn.status === 302
       assert get_flash(conn, :error) === "Submission not found"
+    end
+
+    test "failure: attempting to update a submission as a Challenge Owner", %{conn: conn} do
+      conn = prep_conn_challenge_owner(conn)
+      %{current_user: challenge_owner} = conn.assigns
+      solver_user = AccountHelpers.create_user(%{email: "solver@example.com"})
+
+      challenge =
+        ChallengeHelpers.create_single_phase_challenge(challenge_owner, %{
+          user_id: challenge_owner.id
+        })
+
+      submission = SubmissionHelpers.create_submitted_submission(%{}, solver_user, challenge)
+
+      params = %{
+        "action" => "review",
+        "submission" => %{
+          "title" => "New test title",
+          "brief_description" => "New test brief description",
+          "description" => "New test description",
+          "external_url" => "www.test_example.com"
+        }
+      }
+
+      conn = put(conn, Routes.submission_path(conn, :update, submission.id), params)
+
+      assert get_flash(conn, :error) === "You are not authorized"
+      assert redirected_to(conn) === Routes.dashboard_path(conn, :index)
     end
   end
 
@@ -859,6 +1210,28 @@ defmodule Web.SubmissionControllerTest do
                  submission.challenge_id,
                  submission.phase_id
                )
+    end
+
+    test "failure: deleting a submitted submission as a Challenge Owner", %{conn: conn} do
+      conn = prep_conn_challenge_owner(conn)
+      %{current_user: challenge_owner} = conn.assigns
+      solver_user = AccountHelpers.create_user(%{email: "solver@example.com", role: "solver"})
+
+      challenge =
+        ChallengeHelpers.create_single_phase_challenge(challenge_owner, %{
+          user_id: challenge_owner.id
+        })
+
+      submission =
+        SubmissionHelpers.create_submitted_submission(
+          solver_user,
+          challenge
+        )
+
+      conn = delete(conn, Routes.submission_path(conn, :delete, submission))
+
+      assert get_flash(conn, :error) === "You are not authorized"
+      assert redirected_to(conn) === Routes.dashboard_path(conn, :index)
     end
   end
 

--- a/test/web/controllers/submission_controller_test.exs
+++ b/test/web/controllers/submission_controller_test.exs
@@ -737,7 +737,7 @@ defmodule Web.SubmissionControllerTest do
 
       different_challenge_owner =
         AccountHelpers.create_user(%{
-          email: "challenge_owner@example.com",
+          email: "challenge_owner2@example.com",
           role: "challenge_owner"
         })
 
@@ -873,7 +873,9 @@ defmodule Web.SubmissionControllerTest do
   end
 
   defp prep_conn_challenge_owner(conn) do
-    user = AccountHelpers.create_user(%{email: "admin@example.com", role: "challenge_owner"})
+    user =
+      AccountHelpers.create_user(%{email: "challenge_owner@example.com", role: "challenge_owner"})
+
     assign(conn, :current_user, user)
   end
 end

--- a/test/web/views/message_context_view_test.exs
+++ b/test/web/views/message_context_view_test.exs
@@ -1,0 +1,27 @@
+defmodule Web.MessageContextViewTest do
+  use Web.ConnCase, async: true
+
+  alias Web.MessageContextView
+
+  describe "get active message filter class" do
+    test "success: all" do
+      conn = %{params: %{}}
+
+      assert MessageContextView.filter_active_class(conn, "all") == "btn-primary"
+      assert MessageContextView.filter_active_class(conn, "non_active_filter") == "btn-link"
+    end
+
+    test "success: starred" do
+      conn = %{
+        params: %{
+          "filter" => %{
+            "starred" => "true"
+          }
+        }
+      }
+
+      assert MessageContextView.filter_active_class(conn, "starred") == "btn-primary"
+      assert MessageContextView.filter_active_class(conn, "non_active_filter") == "btn-link"
+    end
+  end
+end


### PR DESCRIPTION
Add phase winners and winners to challenge api call

#### Changes
* update display to reflect changes
* update disable winners tab calculation


- [ ] README is up to date
- [ ] Docs are up to date with changes (modules and functions)
- [x] Tests are included for changes
- [ ] Links in emails use the `_url` route helpers
- [ ] Controllers modified contain appropriate authorization plugs
