### PR TITLE
Refactor of submission form checkbox validations: solver vs admin

### DIFF
--- a/lib/challenge_gov/submissions.ex
+++ b/lib/challenge_gov/submissions.ex
@@ -62,7 +62,7 @@ defmodule ChallengeGov.Submissions do
     |> where([s], is_nil(s.deleted_at))
     |> where([s], s.submitter_id == ^user_id)
     |> where([s], not is_nil(s.manager_id))
-    |> where([s], s.review_verified == false)
+    |> where([s], s.review_verified == false or is_nil(s.review_verified))
     |> Repo.paginate(opts[:page], opts[:per])
   end
 

--- a/lib/web/templates/submission/_form.html.eex
+++ b/lib/web/templates/submission/_form.html.eex
@@ -63,7 +63,7 @@
     <%= FormView.text_field(f, :external_url, label: "External URL (optional)") %>
     <br/>
 
-    <%= accept_terms(@conn, f, @data.submitter_id, @user, @challenge) %>
+    <%= accept_terms(@conn, f, @user, @challenge) %>
     <%= verify_review(f, @user.id, @data) %>
 
     <%= cancel_button(@conn, @action, @challenge, @phase, @user) %>

--- a/lib/web/templates/submission/_form.html.eex
+++ b/lib/web/templates/submission/_form.html.eex
@@ -63,7 +63,7 @@
     <%= FormView.text_field(f, :external_url, label: "External URL (optional)") %>
     <br/>
 
-    <%= accept_terms(@conn, f, @data.submitter_id, @user.id, @challenge) %>
+    <%= accept_terms(@conn, f, @data.submitter_id, @user, @challenge) %>
     <%= verify_review(f, @user.id, @data) %>
 
     <%= cancel_button(@conn, @action, @challenge, @phase, @user) %>

--- a/lib/web/views/submission_view.ex
+++ b/lib/web/views/submission_view.ex
@@ -166,7 +166,7 @@ defmodule Web.SubmissionView do
     link("Cancel", to: route, class: "btn btn-link")
   end
 
-  def accept_terms(conn, form, submitter_id, user, challenge) do
+  def accept_terms(conn, form, user, challenge) do
     # show for solvers even on editing
     if Accounts.is_solver?(user) do
       content_tag(:div, class: "form-group") do

--- a/lib/web/views/submission_view.ex
+++ b/lib/web/views/submission_view.ex
@@ -166,8 +166,9 @@ defmodule Web.SubmissionView do
     link("Cancel", to: route, class: "btn btn-link")
   end
 
-  def accept_terms(conn, form, submitter_id, user_id, challenge) do
-    if is_nil(submitter_id) or submitter_id == user_id do
+  def accept_terms(conn, form, submitter_id, user, challenge) do
+    # show for solvers even on editing
+    if Accounts.is_solver?(user) do
       content_tag(:div, class: "form-group") do
         content_tag(:div, class: "col") do
           [

--- a/test/support/test_helpers/submission_helpers.ex
+++ b/test/support/test_helpers/submission_helpers.ex
@@ -12,9 +12,7 @@ defmodule ChallengeGov.TestHelpers.SubmissionHelpers do
         "title" => "Test Title",
         "brief_description" => "Test Brief Description",
         "description" => "Test Description",
-        "external_url" => "www.example.com",
-        "terms_accepted" => "true",
-        "review_verified" => "true"
+        "external_url" => "www.example.com"
       },
       attributes
     )


### PR DESCRIPTION
Refactor  checkboxes on submission form: admins don't have them, solvers must check terms and maybe review verify
