### PR TITLE
Chal 636/challenge owner edits to challenge in review

### DIFF
--- a/lib/challenge_gov/challenges.ex
+++ b/lib/challenge_gov/challenges.ex
@@ -912,22 +912,21 @@ defmodule ChallengeGov.Challenges do
   end
 
   def set_status(current_user, challenge, status, remote_ip) do
-    result =
-      challenge
-      |> Ecto.Changeset.change()
-      |> Ecto.Changeset.put_change(:status, status)
-      |> Repo.update()
-      |> case do
-        {:ok, challenge} ->
-          add_to_security_log(current_user, challenge, "status_change", remote_ip, %{
-            status: status
-          })
+    challenge
+    |> Ecto.Changeset.change()
+    |> Ecto.Changeset.put_change(:status, status)
+    |> Repo.update()
+    |> case do
+      {:ok, challenge} ->
+        add_to_security_log(current_user, challenge, "status_change", remote_ip, %{
+          status: status
+        })
 
-          {:ok, challenge}
+        {:ok, challenge}
 
-        {:error, changeset} ->
-          {:error, changeset}
-      end
+      {:error, changeset} ->
+        {:error, changeset}
+    end
   end
 
   # BOOKMARK: Advanced status functions

--- a/lib/challenge_gov/challenges.ex
+++ b/lib/challenge_gov/challenges.ex
@@ -911,6 +911,25 @@ defmodule ChallengeGov.Challenges do
     end
   end
 
+  def set_status(current_user, challenge, status, remote_ip) do
+    result =
+      challenge
+      |> Ecto.Changeset.change()
+      |> Ecto.Changeset.put_change(:status, status)
+      |> Repo.update()
+      |> case do
+        {:ok, challenge} ->
+          add_to_security_log(current_user, challenge, "status_change", remote_ip, %{
+            status: status
+          })
+
+          {:ok, challenge}
+
+        {:error, changeset} ->
+          {:error, changeset}
+      end
+  end
+
   # BOOKMARK: Advanced status functions
   @doc """
   Checks if the challenge should be publicly accessible. Either published or archived

--- a/lib/web/controllers/challenge_controller.ex
+++ b/lib/web/controllers/challenge_controller.ex
@@ -1,5 +1,6 @@
 defmodule Web.ChallengeController do
   use Web, :controller
+  use Phoenix.HTML
 
   alias ChallengeGov.Challenges
   alias ChallengeGov.Security
@@ -155,8 +156,9 @@ defmodule Web.ChallengeController do
     with {:ok, challenge} <- Challenges.get(id),
          {:ok, challenge} <- Challenges.allowed_to_edit(user, challenge) do
       conn
-      |> assign(:user, user)
       |> assign(:challenge, challenge)
+      |> maybe_reset_challenge_status(user, challenge)
+      |> assign(:user, user)
       |> assign(:path, Routes.challenge_path(conn, :update, id))
       |> assign(:action, action_name(conn))
       |> assign(:show_info, false)
@@ -455,4 +457,19 @@ defmodule Web.ChallengeController do
       |> redirect(to: Routes.challenge_path(conn, :edit, challenge.id, section))
     end
   end
+
+  defp maybe_reset_challenge_status(conn, user = %{role: "challenge_owner"}, challenge = %{status: "gsa_review"}) do
+    remote_ip = Security.extract_remote_ip(conn)
+    {:ok, challenge} = Challenges.set_status(user, challenge, "draft", remote_ip)
+
+    conn
+    |> put_flash(:warning, [
+      content_tag(:span, "Challenge Removed from Queue", class: "h4"),
+      content_tag(:br, ""),
+      "Once edits are made you will need to resubmit this challenge for GSA approval"
+    ])
+    |> assign(:challenge, challenge)
+  end
+
+  defp maybe_reset_challenge_status(conn, _user, _challenge), do: conn
 end

--- a/lib/web/controllers/challenge_controller.ex
+++ b/lib/web/controllers/challenge_controller.ex
@@ -458,7 +458,11 @@ defmodule Web.ChallengeController do
     end
   end
 
-  defp maybe_reset_challenge_status(conn, user = %{role: "challenge_owner"}, challenge = %{status: "gsa_review"}) do
+  defp maybe_reset_challenge_status(
+         conn,
+         user = %{role: "challenge_owner"},
+         challenge = %{status: "gsa_review"}
+       ) do
     remote_ip = Security.extract_remote_ip(conn)
     {:ok, challenge} = Challenges.set_status(user, challenge, "draft", remote_ip)
 

--- a/lib/web/templates/challenge/index.html.eex
+++ b/lib/web/templates/challenge/index.html.eex
@@ -26,7 +26,7 @@
     <div class="row mb-2">
       <div class="col-sm-6">
         <h1 class="m-0 text-dark">
-          <span>Challenges</span>
+          <span>All Challenges</span>
           <div class="btn-group">
             <%= link "New", to: Routes.challenge_path(@conn, :new, show_info: true), class: "btn btn-primary" %>
           </div>

--- a/lib/web/templates/layout/app.html.eex
+++ b/lib/web/templates/layout/app.html.eex
@@ -139,7 +139,17 @@
               </div>
             </div>
           </div>
-          <% end %>
+        <% end %>
+
+        <%= if get_flash(@conn, :warning) do %>
+          <div class="content-header">
+            <div class="container-fluid">
+              <div class="callout callout-warning">
+                <i class="fa fa-exclamation-circle"></i> <%= get_flash(@conn, :warning) %>
+              </div>
+            </div>
+          </div>
+        <% end %>
       <%= @inner_content %>          
       </div>
       <aside class="control-sidebar control-sidebar-light">

--- a/test/web/controllers/submission_controller_test.exs
+++ b/test/web/controllers/submission_controller_test.exs
@@ -873,7 +873,9 @@ defmodule Web.SubmissionControllerTest do
   end
 
   defp prep_conn_challenge_owner(conn) do
-    user = AccountHelpers.create_user(%{email: "admin@example.com", role: "challenge_owner"})
+    user =
+      AccountHelpers.create_user(%{email: "challenge_owner@example.com", role: "challenge_owner"})
+
     assign(conn, :current_user, user)
   end
 end

--- a/test/web/controllers/submission_controller_test.exs
+++ b/test/web/controllers/submission_controller_test.exs
@@ -737,7 +737,7 @@ defmodule Web.SubmissionControllerTest do
 
       different_challenge_owner =
         AccountHelpers.create_user(%{
-          email: "challenge_owner@example.com",
+          email: "challenge_owner2@example.com",
           role: "challenge_owner"
         })
 


### PR DESCRIPTION
For challenges in gsa_review, editing a section as a challenges owner sets the status to draft and notifies them the challenge has been removed from review

### Changes
- update status on edit for challenge owner
- add :warning flash message
- update challenge table header to include "All"

Tests
- edit action
- update action

- [ ] README is up to date
- [ ] Docs are up to date with changes (modules and functions)
- [ ] Tests are included for changes
- [ ] Links in emails use the `_url` route helpers
- [ ] Controllers modified contain appropriate authorization plugs
