### PR TITLE
Add meta data tags to public page head

### DIFF
--- a/assets/client/src/index.js
+++ b/assets/client/src/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { HashRouter, Redirect, Switch, Route } from "react-router-dom";
+import { BrowserRouter, Redirect, Switch, Route } from "react-router-dom";
 import { IndexRoutes } from "./routes/index";
 import * as serviceWorker from './serviceWorker';
 import { useTracking } from './useTracking'
@@ -39,9 +39,9 @@ const renderRouter = () => (
     apiUrl: apiUrl || window.location.origin,
     imageBase: imageBase || ""
   }}>
-    <HashRouter>
+    <BrowserRouter basename="/public">
       <Application />
-    </HashRouter>
+    </BrowserRouter>
   </ApiUrlContext.Provider>
 )
 

--- a/lib/web/controllers/public/page_controller.ex
+++ b/lib/web/controllers/public/page_controller.ex
@@ -1,8 +1,38 @@
 defmodule Web.Public.PageController do
   use Web, :controller
 
-  def index(conn, _params) do
-    conn
-    |> render("index.html")
+  alias ChallengeGov.Challenges
+  alias ChallengeGov.Challenges.Logo
+  alias Stein.Storage
+
+  def index(conn, params) do
+    case Map.has_key?(params, "id") do
+      true ->
+        %{"id" => id} = params
+        {:ok, challenge} = Challenges.get(id)
+
+        challenge_image = get_open_graph_image(challenge)
+
+        conn
+        |> assign(:og_title, challenge.title)
+        |> assign(:og_description, HtmlSanitizeEx.strip_tags(challenge.brief_description))
+        |> assign(:og_image, challenge_image)
+        |> render("index.html")
+
+      false ->
+        conn
+        |> render("index.html")
+    end
+  end
+
+  defp get_open_graph_image(challenge) do
+    if challenge.upload_logo do
+      custom_image_path =
+        Storage.url(Logo.logo_path(challenge, "original"), signed: [expires_in: 3600])
+
+      Routes.static_url(Web.Endpoint, custom_image_path)
+    else
+      Routes.static_url(Web.Endpoint, "/images/challenge-logo-2_1.svg")
+    end
   end
 end

--- a/lib/web/router.ex
+++ b/lib/web/router.ex
@@ -235,8 +235,8 @@ defmodule Web.Router do
 
     get("/", PageController, :index)
     get("/challenges", PageController, :index, as: :challenge_index)
-    get("/challenges#/challenge/:id", PageController, :index, as: :challenge_details)
-    get("/challenges#/challenge/:id/:tab", PageController, :index, as: :challenge_details)
+    get("/challenge/:id", PageController, :index, as: :challenge_details)
+    get("/challenge/:id/:tab", PageController, :index, as: :challenge_details)
   end
 
   if Mix.env() == :dev do

--- a/lib/web/templates/layout/_header.html.eex
+++ b/lib/web/templates/layout/_header.html.eex
@@ -1,5 +1,5 @@
 <nav class="header navbar navbar-expand-lg navbar-light">
-  <%= link(to: Routes.public_page_path(@conn, :index), class: "navbar-brand", href: "#") do %>
+  <%= link(to: Routes.public_page_path(@conn, :index), class: "navbar-brand", href: "/public") do %>
     <img src='<%= Routes.static_path(@conn, "/images/challenge-logo.png") %>' alt="Challenge Gov Logo" title="Challenge Gov" class="header__challenge-logo">
   <% end %>
 

--- a/lib/web/templates/layout/root.html.eex
+++ b/lib/web/templates/layout/root.html.eex
@@ -13,6 +13,20 @@
 
     <title>Challenge.Gov</title>
 
+    <%= if Map.has_key?(@conn.assigns, :og_description) do %>
+      <meta property="og:description" content="<%= @conn.assigns.og_description %>" />
+    <% end %>
+
+    <%= if Map.has_key?(assigns, :og_image) do %>
+      <meta property="og:image" content="<%= @og_image %>">
+    <% end %>
+
+    <%= if Map.has_key?(@conn.assigns, :og_title) do %>
+      <meta property="og:title" content="<%= @conn.assigns.og_title %>">
+    <% end %>
+
+    <meta name="twitter:card" content="summary_large_image">
+
     <meta name="csrf-token" content="<%= Plug.CSRFProtection.get_csrf_token() %>">
   </head>
 

--- a/test/web/controllers/saved_challenge_controller_test.exs
+++ b/test/web/controllers/saved_challenge_controller_test.exs
@@ -156,7 +156,7 @@ defmodule Web.SavedChallengeControllerTest do
                       "href",
                       61,
                       34,
-                      "http://localhost:4002/public/challenges#/challenge/#{challenge.id}",
+                      "http://localhost:4002/public/challenge/#{challenge.id}",
                       34
                     ]
                   ],


### PR DESCRIPTION
Add meta tags so that social sharing cards render correctly


### Changes

assets/client/src/index.js
* switch from hashrouter to browser router so we can fetch challenge
from params in page controller

router.ex
* remove /challenges and # from public :challenge_details routes

public/page_controller.ex
* assign open graph values to conn if params incl id

layout/_header.html.eex
* update header icon home link

layout/root.html.eex
* add meta tags to head

saved_challenge_controller_test.exs
* update route in test

- [ ] README is up to date
- [ ] Docs are up to date with changes (modules and functions)
- [ ] Tests are included for changes
- [ ] Links in emails use the `_url` route helpers
- [ ] Controllers modified contain appropriate authorization plugs
