### PR TITLE
Chal - 633 test using a non-svg image

### DIFF
--- a/lib/web/controllers/public/page_controller.ex
+++ b/lib/web/controllers/public/page_controller.ex
@@ -32,7 +32,7 @@ defmodule Web.Public.PageController do
 
       Routes.static_url(Web.Endpoint, custom_image_path)
     else
-      Routes.static_url(Web.Endpoint, "/images/challenge-logo-2_1.svg")
+      Routes.static_url(Web.Endpoint, "/images/challenge-logo.png")
     end
   end
 end

--- a/lib/web/controllers/public/page_controller.ex
+++ b/lib/web/controllers/public/page_controller.ex
@@ -27,10 +27,7 @@ defmodule Web.Public.PageController do
 
   defp get_open_graph_image(challenge) do
     if challenge.upload_logo do
-      custom_image_path =
-        Storage.url(Logo.logo_path(challenge, "original"), signed: [expires_in: 3600])
-
-      Routes.static_url(Web.Endpoint, custom_image_path)
+      Storage.url(Logo.logo_path(challenge, "original"), signed: [expires_in: 3600])
     else
       Routes.static_url(Web.Endpoint, "/images/challenge-logo.png")
     end


### PR DESCRIPTION
### Issues

Image not rendering in card on manual testing and on validators 
* because svgs not supported?

Challenges with custom logos not rendering
* get_open_graph_image path is wrong?

_custom_image_path:_
"/uploads/challenges/original-6f52b1fb-796c-4d50-994c-8b770f191a12.png"

_combined with static_url:_
"http://localhost:4000/uploads/challenges/original-6f52b1fb-796c-4d50-994c-8b770f191a12.png"

### Fixes
Set default challenge logo to a png

Remove `Routes.static_url(Web.Endpoint, custom_image_path)` and just return the S3 path

- [ ] README is up to date
- [ ] Docs are up to date with changes (modules and functions)
- [ ] Tests are included for changes
- [ ] Links in emails use the `_url` route helpers
- [ ] Controllers modified contain appropriate authorization plugs
