### PR TITLE
CHAL 633 - static meta tags

### DIFF
--- a/assets/client/src/components/ChallengeDetails.js
+++ b/assets/client/src/components/ChallengeDetails.js
@@ -1,8 +1,7 @@
 import React, { useContext, useEffect, useState } from 'react'
-import { Tooltip } from 'reactstrap'
 import moment from "moment"
 import { stripHtml } from "string-strip-html";
-import {FacebookShareButton, LinkedinShareButton, TwitterShareButton, EmailShareButton} from "react-share";
+import { Tooltip } from 'reactstrap'
 
 import { ChallengeTabs } from "../components/ChallengeTabs"
 import { Overview } from "../components/challenge_tabs/Overview"
@@ -15,6 +14,7 @@ import { Resources } from "../components/challenge_tabs/Resources"
 import { FAQ } from "../components/challenge_tabs/FAQ"
 import { ContactForm } from "../components/challenge_tabs/ContactForm"
 import { Winners } from "../components/challenge_tabs/Winners"
+import { SocialSharingTooltip } from "../components/SocialSharingTooltip"
 import { documentsForSection } from "../helpers/documentHelpers"
 import { getPreviousPhase, getCurrentPhase, getNextPhase, phaseInPast, phaseIsCurrent, phaseInFuture, phaseNumber, isSinglePhase, formatDateTime, formatDate } from '../helpers/phaseHelpers'
 import { ChallengeAnnouncement } from './ChallengeAnnouncement'
@@ -27,8 +27,6 @@ export const ChallengeDetails = ({challenge, challengePhases, preview, print, ta
 
   const toggleFollowTooltip = () => setFollowTooltipOpen(!followTooltipOpen)
   const toggleShareTooltip = () => setShareTooltipOpen(!shareTooltipOpen)
-
-  const challengeURL = window.location.href
 
   const renderEndDate = (date) => {
     const fiveDaysFromNow = moment().add(5,'d').utc().format()
@@ -106,37 +104,6 @@ export const ChallengeDetails = ({challenge, challengePhases, preview, print, ta
       <Tooltip placement="bottom" trigger="click" isOpen={followTooltipOpen} target="followChallengeButton" toggle={toggleFollowTooltip} autohide={false} className="follow-tooltip" innerClassName="follow-tooltip__inner" arrowClassName="follow-tooltip__arrow">
         {renderSubscribeButton()}
         {renderSaveButton()}
-      </Tooltip>
-    )
-  }
-
-  const renderShareTooltip = () => {
-    return (
-      <Tooltip placement="bottom" trigger="click" isOpen={shareTooltipOpen} target="shareChallengeButton" toggle={toggleShareTooltip} autohide={false} className="share-tooltip" innerClassName="share-tooltip__inner" arrowClassName="share-tooltip__arrow">
-        <FacebookShareButton url={challengeURL} quote="Check out this awesome challenge" hashtag="#prizechallenge">
-          <svg viewBox="0 0 64 64" width="32" height="32">
-            <circle cx="32" cy="32" r="31" fill="#3b5998"></circle>
-            <path d="M34.1,47V33.3h4.6l0.7-5.3h-5.3v-3.4c0-1.5,0.4-2.6,2.6-2.6l2.8,0v-4.8c-0.5-0.1-2.2-0.2-4.1-0.2 c-4.1,0-6.9,2.5-6.9,7V28H24v5.3h4.6V47H34.1z" fill="white"></path>
-          </svg>
-        </FacebookShareButton>
-        <LinkedinShareButton url={challengeURL} title="Title of the shared page" summary="Description of the shared page" source="Source of the content (e.g. your website or application name)">
-          <svg viewBox="0 0 64 64" width="32" height="32">
-            <circle cx="32" cy="32" r="31" fill="#007fb1"></circle>
-            <path d="M20.4,44h5.4V26.6h-5.4V44z M23.1,18c-1.7,0-3.1,1.4-3.1,3.1c0,1.7,1.4,3.1,3.1,3.1 c1.7,0,3.1-1.4,3.1-3.1C26.2,19.4,24.8,18,23.1,18z M39.5,26.2c-2.6,0-4.4,1.4-5.1,2.8h-0.1v-2.4h-5.2V44h5.4v-8.6 c0-2.3,0.4-4.5,3.2-4.5c2.8,0,2.8,2.6,2.8,4.6V44H46v-9.5C46,29.8,45,26.2,39.5,26.2z" fill="white"></path>
-          </svg>
-        </LinkedinShareButton>
-        <TwitterShareButton url={challengeURL} title="Title of the shared page" via="ChallengeGov" hashtags={["prizechallenge", "innovation"]} related={["Accounts to recommend following", "?"]}>
-          <svg viewBox="0 0 64 64" width="32" height="32">
-            <circle cx="32" cy="32" r="31" fill="#00aced"></circle>
-            <path d="M48,22.1c-1.2,0.5-2.4,0.9-3.8,1c1.4-0.8,2.4-2.1,2.9-3.6c-1.3,0.8-2.7,1.3-4.2,1.6 C41.7,19.8,40,19,38.2,19c-3.6,0-6.6,2.9-6.6,6.6c0,0.5,0.1,1,0.2,1.5c-5.5-0.3-10.3-2.9-13.5-6.9c-0.6,1-0.9,2.1-0.9,3.3 c0,2.3,1.2,4.3,2.9,5.5c-1.1,0-2.1-0.3-3-0.8c0,0,0,0.1,0,0.1c0,3.2,2.3,5.8,5.3,6.4c-0.6,0.1-1.1,0.2-1.7,0.2c-0.4,0-0.8,0-1.2-0.1 c0.8,2.6,3.3,4.5,6.1,4.6c-2.2,1.8-5.1,2.8-8.2,2.8c-0.5,0-1.1,0-1.6-0.1c2.9,1.9,6.4,2.9,10.1,2.9c12.1,0,18.7-10,18.7-18.7 c0-0.3,0-0.6,0-0.8C46,24.5,47.1,23.4,48,22.1z" fill="white"></path>
-          </svg>
-        </TwitterShareButton>
-        <EmailShareButton url={challengeURL} subject="Subject of this email?" body="Can put a body message here" separator=" ">
-          <svg viewBox="0 0 64 64" width="32" height="32">
-            <circle cx="32" cy="32" r="31" fill="#7f7f7f"></circle>
-            <path d="M17,22v20h30V22H17z M41.1,25L32,32.1L22.9,25H41.1z M20,39V26.6l12,9.3l12-9.3V39H20z" fill="white"></path>
-          </svg>
-        </EmailShareButton>
       </Tooltip>
     )
   }
@@ -376,7 +343,7 @@ export const ChallengeDetails = ({challenge, challengePhases, preview, print, ta
                       <i className="fas fa-share-alt"></i>
                       share
                     </span>
-                    {renderShareTooltip()}
+                    <SocialSharingTooltip shareTooltipOpen={shareTooltipOpen} toggleShareTooltip={toggleShareTooltip} />
                   </div>
                 </>
               }

--- a/assets/client/src/components/SocialSharingTooltip.js
+++ b/assets/client/src/components/SocialSharingTooltip.js
@@ -1,0 +1,36 @@
+import React from 'react'
+import { Tooltip } from 'reactstrap'
+import {FacebookShareButton, LinkedinShareButton, TwitterShareButton, EmailShareButton} from "react-share";
+
+export const SocialSharingTooltip = ({shareTooltipOpen, toggleShareTooltip}) => {
+  const challengeURL = window.location.href
+
+  return (
+    <Tooltip placement="bottom" trigger="click" isOpen={shareTooltipOpen} target="shareChallengeButton" toggle={toggleShareTooltip} autohide={false} className="share-tooltip" innerClassName="share-tooltip__inner" arrowClassName="share-tooltip__arrow">
+      <FacebookShareButton url={challengeURL} quote="Check out this awesome challenge" hashtag="#prizechallenge">
+        <svg viewBox="0 0 64 64" width="32" height="32">
+          <circle cx="32" cy="32" r="31" fill="#3b5998"></circle>
+          <path d="M34.1,47V33.3h4.6l0.7-5.3h-5.3v-3.4c0-1.5,0.4-2.6,2.6-2.6l2.8,0v-4.8c-0.5-0.1-2.2-0.2-4.1-0.2 c-4.1,0-6.9,2.5-6.9,7V28H24v5.3h4.6V47H34.1z" fill="white"></path>
+        </svg>
+      </FacebookShareButton>
+      <LinkedinShareButton url={challengeURL} title="Title of the shared page" summary="Description of the shared page" source="Source of the content (e.g. your website or application name)">
+        <svg viewBox="0 0 64 64" width="32" height="32">
+          <circle cx="32" cy="32" r="31" fill="#007fb1"></circle>
+          <path d="M20.4,44h5.4V26.6h-5.4V44z M23.1,18c-1.7,0-3.1,1.4-3.1,3.1c0,1.7,1.4,3.1,3.1,3.1 c1.7,0,3.1-1.4,3.1-3.1C26.2,19.4,24.8,18,23.1,18z M39.5,26.2c-2.6,0-4.4,1.4-5.1,2.8h-0.1v-2.4h-5.2V44h5.4v-8.6 c0-2.3,0.4-4.5,3.2-4.5c2.8,0,2.8,2.6,2.8,4.6V44H46v-9.5C46,29.8,45,26.2,39.5,26.2z" fill="white"></path>
+        </svg>
+      </LinkedinShareButton>
+      <TwitterShareButton url={challengeURL} title="Title of the shared page" via="ChallengeGov" hashtags={["prizechallenge", "innovation"]} related={["Accounts to recommend following", "?"]}>
+        <svg viewBox="0 0 64 64" width="32" height="32">
+          <circle cx="32" cy="32" r="31" fill="#00aced"></circle>
+          <path d="M48,22.1c-1.2,0.5-2.4,0.9-3.8,1c1.4-0.8,2.4-2.1,2.9-3.6c-1.3,0.8-2.7,1.3-4.2,1.6 C41.7,19.8,40,19,38.2,19c-3.6,0-6.6,2.9-6.6,6.6c0,0.5,0.1,1,0.2,1.5c-5.5-0.3-10.3-2.9-13.5-6.9c-0.6,1-0.9,2.1-0.9,3.3 c0,2.3,1.2,4.3,2.9,5.5c-1.1,0-2.1-0.3-3-0.8c0,0,0,0.1,0,0.1c0,3.2,2.3,5.8,5.3,6.4c-0.6,0.1-1.1,0.2-1.7,0.2c-0.4,0-0.8,0-1.2-0.1 c0.8,2.6,3.3,4.5,6.1,4.6c-2.2,1.8-5.1,2.8-8.2,2.8c-0.5,0-1.1,0-1.6-0.1c2.9,1.9,6.4,2.9,10.1,2.9c12.1,0,18.7-10,18.7-18.7 c0-0.3,0-0.6,0-0.8C46,24.5,47.1,23.4,48,22.1z" fill="white"></path>
+        </svg>
+      </TwitterShareButton>
+      <EmailShareButton url={challengeURL} subject="Subject of this email?" body="Can put a body message here" separator=" ">
+        <svg viewBox="0 0 64 64" width="32" height="32">
+          <circle cx="32" cy="32" r="31" fill="#7f7f7f"></circle>
+          <path d="M17,22v20h30V22H17z M41.1,25L32,32.1L22.9,25H41.1z M20,39V26.6l12,9.3l12-9.3V39H20z" fill="white"></path>
+        </svg>
+      </EmailShareButton>
+    </Tooltip>
+  )
+}

--- a/assets/client/src/index.js
+++ b/assets/client/src/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { BrowserRouter, Redirect, Switch, Route } from "react-router-dom";
+import { HashRouter, Redirect, Switch, Route } from "react-router-dom";
 import { IndexRoutes } from "./routes/index";
 import * as serviceWorker from './serviceWorker';
 import { useTracking } from './useTracking'
@@ -39,9 +39,9 @@ const renderRouter = () => (
     apiUrl: apiUrl || window.location.origin,
     imageBase: imageBase || ""
   }}>
-    <BrowserRouter basename="/public">
+    <HashRouter>
       <Application />
-    </BrowserRouter>
+    </HashRouter>
   </ApiUrlContext.Provider>
 )
 

--- a/lib/web/controllers/public/page_controller.ex
+++ b/lib/web/controllers/public/page_controller.ex
@@ -1,38 +1,8 @@
 defmodule Web.Public.PageController do
   use Web, :controller
 
-  alias ChallengeGov.Challenges
-  alias ChallengeGov.Challenges.Logo
-  alias Stein.Storage
-
-  def index(conn, params) do
-    case Map.has_key?(params, "id") do
-      true ->
-        %{"id" => id} = params
-        {:ok, challenge} = Challenges.get(id)
-
-        challenge_image = get_open_graph_image(challenge)
-
-        conn
-        |> assign(:og_title, challenge.title)
-        |> assign(:og_description, HtmlSanitizeEx.strip_tags(challenge.brief_description))
-        |> assign(:og_image, challenge_image)
-        |> render("index.html")
-
-      false ->
-        conn
-        |> render("index.html")
-    end
-  end
-
-  defp get_open_graph_image(challenge) do
-    if challenge.upload_logo do
-      custom_image_path =
-        Storage.url(Logo.logo_path(challenge, "original"), signed: [expires_in: 3600])
-
-      Routes.static_url(Web.Endpoint, custom_image_path)
-    else
-      Routes.static_url(Web.Endpoint, "/images/challenge-logo-2_1.svg")
-    end
+  def index(conn, _params) do
+    conn
+    |> render("index.html")
   end
 end

--- a/lib/web/router.ex
+++ b/lib/web/router.ex
@@ -236,8 +236,8 @@ defmodule Web.Router do
 
     get("/", PageController, :index)
     get("/challenges", PageController, :index, as: :challenge_index)
-    get("/challenge/:id", PageController, :index, as: :challenge_details)
-    get("/challenge/:id/:tab", PageController, :index, as: :challenge_details)
+    get("/challenges#/challenge/:id", PageController, :index, as: :challenge_details)
+    get("/challenges#/challenge/:id/:tab", PageController, :index, as: :challenge_details)
   end
 
   if Mix.env() == :dev do

--- a/lib/web/templates/layout/_header.html.eex
+++ b/lib/web/templates/layout/_header.html.eex
@@ -1,5 +1,5 @@
 <nav class="header navbar navbar-expand-lg navbar-light">
-  <%= link(to: Routes.public_page_path(@conn, :index), class: "navbar-brand", href: "/public") do %>
+  <%= link(to: Routes.public_page_path(@conn, :index), class: "navbar-brand", href: "#") do %>
     <img src='<%= Routes.static_path(@conn, "/images/challenge-logo.png") %>' alt="Challenge Gov Logo" title="Challenge Gov" class="header__challenge-logo">
   <% end %>
 

--- a/lib/web/templates/layout/root.html.eex
+++ b/lib/web/templates/layout/root.html.eex
@@ -13,17 +13,11 @@
 
     <title>Challenge.Gov</title>
 
-    <%= if Map.has_key?(@conn.assigns, :og_description) do %>
-      <meta property="og:description" content="<%= @conn.assigns.og_description %>" />
-    <% end %>
+    <meta property="og:description" content="Challenge.Gov emppowers federal agencies to engage public solvers in challenges and prize competitions to identify innovative solutions to critical issues." />
 
-    <%= if Map.has_key?(assigns, :og_image) do %>
-      <meta property="og:image" content="<%= @og_image %>">
-    <% end %>
+    <meta property="og:image" content="https://challenge-portal-dev.app.cloud.gov/images/challenge-logo-ac86bd43b87671f7ff2531f2f4452982.png?vsn=d">
 
-    <%= if Map.has_key?(@conn.assigns, :og_title) do %>
-      <meta property="og:title" content="<%= @conn.assigns.og_title %>">
-    <% end %>
+    <meta property="og:title" content="Challenge.Gov">
 
     <meta name="twitter:card" content="summary_large_image">
 

--- a/test/web/controllers/saved_challenge_controller_test.exs
+++ b/test/web/controllers/saved_challenge_controller_test.exs
@@ -156,7 +156,7 @@ defmodule Web.SavedChallengeControllerTest do
                       "href",
                       61,
                       34,
-                      "http://localhost:4002/public/challenge/#{challenge.id}",
+                      "http://localhost:4002/public/challenges#/challenge/#{challenge.id}",
                       34
                     ]
                   ],


### PR DESCRIPTION
Revert dynamic meta tag setting, PR https://github.com/GSA/Challenge_gov/pull/300

src/index.js
* reset hashrouter

layout/root.html.eex
* set static meta tags

layout/_header.html.eex / saved_challenge_controller_test.exs / router.ex
* reset hash and url routing

public/page_controller.ex
* revert fetching and assigning challenge data

components/SocialSharingTooltip.js / ChallengeDetails.js
* move social sharing tooltip to own component

- [ ] README is up to date
- [ ] Docs are up to date with changes (modules and functions)
- [ ] Tests are included for changes
- [ ] Links in emails use the `_url` route helpers
- [ ] Controllers modified contain appropriate authorization plugs
