### PR TITLE
Updated message contexts for new scenarios

### DIFF
--- a/lib/challenge_gov/messages/message_context.ex
+++ b/lib/challenge_gov/messages/message_context.ex
@@ -7,6 +7,7 @@ defmodule ChallengeGov.Messages.MessageContext do
   import Ecto.Changeset
 
   alias ChallengeGov.Messages.Message
+  alias ChallengeGov.Messages.MessageContext
   alias ChallengeGov.Messages.MessageContextStatus
 
   @valid_contexts [
@@ -14,14 +15,16 @@ defmodule ChallengeGov.Messages.MessageContext do
     "submission"
   ]
 
-  # @valid_audiences [
-  #   "admins",
-  #   "challenge_owners",
-  #   "solvers"
-  # ]
+  @valid_audiences [
+    "all",
+    "admins",
+    "challenge_owners"
+  ]
 
   @type t :: %__MODULE__{}
   schema "message_contexts" do
+    belongs_to(:parent, MessageContext)
+    has_many(:contexts, MessageContext)
     has_many(:messages, Message)
     has_many(:statuses, MessageContextStatus)
 
@@ -29,7 +32,7 @@ defmodule ChallengeGov.Messages.MessageContext do
 
     field(:context, :string)
     field(:context_id, :integer)
-    field(:audience, {:array, :string})
+    field(:audience, :string)
 
     timestamps(type: :utc_datetime_usec)
   end
@@ -41,6 +44,7 @@ defmodule ChallengeGov.Messages.MessageContext do
       :context_id,
       :audience
     ])
-    |> validate_inclusion(:context, @valid_contexts)
+    |> validate_inclusion(:context, [nil | @valid_contexts])
+    |> validate_inclusion(:audience, @valid_audiences)
   end
 end

--- a/lib/web/views/message_context_view.ex
+++ b/lib/web/views/message_context_view.ex
@@ -17,8 +17,8 @@ defmodule Web.MessageContextView do
 
   def display_audience(message_context) do
     message_context.audience
-    |> Enum.map(&String.capitalize(&1))
-    |> Enum.join(", ")
+    |> String.replace("_", " ")
+    |> String.capitalize()
   end
 
   def display_challenge_title_link(message_context) do

--- a/priv/repo/migrations/20210726172128_change_message_context_audience_to_string.exs
+++ b/priv/repo/migrations/20210726172128_change_message_context_audience_to_string.exs
@@ -1,0 +1,32 @@
+defmodule ChallengeGov.Repo.Migrations.ChangeMessageContextAudienceToString do
+  use Ecto.Migration
+
+  def up do
+    alter table(:message_contexts) do
+      remove :audience
+    end
+
+    alter table(:message_contexts) do
+      add :audience, :string
+    end
+
+    execute "update message_contexts set audience='all';"
+  end
+
+  def down do
+    alter table(:message_contexts) do
+      remove :audience
+    end
+
+    alter table(:message_contexts) do
+      add :audience, {:array, :string}
+    end
+
+    flush()
+    execute "update message_contexts set audience=ARRAY['solver'];"
+
+    alter table(:message_contexts) do
+      modify :audience, {:array, :string}, null: false
+    end
+  end
+end

--- a/priv/repo/migrations/20210726174345_add_parent_to_message_contexts.exs
+++ b/priv/repo/migrations/20210726174345_add_parent_to_message_contexts.exs
@@ -1,0 +1,9 @@
+defmodule ChallengeGov.Repo.Migrations.AddParentToMessageContexts do
+  use Ecto.Migration
+
+  def change do
+    alter table(:message_contexts) do
+      add :parent_id, references(:message_contexts)
+    end
+  end
+end

--- a/test/challenge_gov/message_context_statuses_test.exs
+++ b/test/challenge_gov/message_context_statuses_test.exs
@@ -34,7 +34,7 @@ defmodule ChallengeGov.MessageContextStatusesTest do
       MessageContexts.create(%{
         "context" => "challenge",
         "context_id" => challenge.id,
-        "audience" => ["solvers"]
+        "audience" => "all"
       })
 
     message_context = Repo.preload(message_context, [:statuses])

--- a/test/challenge_gov/message_contexts_test.exs
+++ b/test/challenge_gov/message_contexts_test.exs
@@ -18,13 +18,13 @@ defmodule ChallengeGov.MessageContextsTest do
       challenge = ChallengeHelpers.create_single_phase_challenge(user, %{user_id: user.id})
       _submission = SubmissionHelpers.create_submitted_submission(%{}, user_solver, challenge)
 
-      _prepped_message_context = MessageContexts.new(["solvers"])
+      _prepped_message_context = MessageContexts.new("all")
 
       {:ok, message_context} =
         MessageContexts.create(%{
           "context" => "challenge",
           "context_id" => challenge.id,
-          "audience" => ["solvers"]
+          "audience" => "all"
         })
 
       user_context_status = Enum.at(MessageContextStatuses.all_for_user(user), 0)
@@ -43,20 +43,20 @@ defmodule ChallengeGov.MessageContextsTest do
       challenge = ChallengeHelpers.create_single_phase_challenge(user, %{user_id: user.id})
       _submission = SubmissionHelpers.create_submitted_submission(%{}, user_solver, challenge)
 
-      _prepped_message_context = MessageContexts.new(["solvers"])
+      _prepped_message_context = MessageContexts.new("all")
 
       {:ok, message_context} =
         MessageContexts.create(%{
           "context" => "challenge",
           "context_id" => challenge.id,
-          "audience" => ["solvers"]
+          "audience" => "all"
         })
 
       {:ok, message_context_2} =
         MessageContexts.create(%{
           "context" => "challenge",
           "context_id" => challenge.id,
-          "audience" => ["solvers"]
+          "audience" => "all"
         })
 
       assert message_context.id == message_context_2.id

--- a/test/challenge_gov/messages_test.exs
+++ b/test/challenge_gov/messages_test.exs
@@ -34,7 +34,7 @@ defmodule ChallengeGov.MessagesTest do
       MessageContexts.create(%{
         "context" => "challenge",
         "context_id" => challenge.id,
-        "audience" => ["solvers"]
+        "audience" => "all"
       })
 
     message_context = Repo.preload(message_context, [:statuses])

--- a/test/support/test_helpers/message_context_status_helpers.ex
+++ b/test/support/test_helpers/message_context_status_helpers.ex
@@ -50,7 +50,7 @@ defmodule ChallengeGov.TestHelpers.MessageContextStatusHelpers do
       MessageContexts.create(%{
         "context" => "challenge",
         "context_id" => challenge.id,
-        "audience" => ["solvers"]
+        "audience" => "all"
       })
 
     message_context = Repo.preload(message_context, [:statuses])


### PR DESCRIPTION
- Changed context audience from array to string
- Added a parent id to message context to handle the case of isolated
  BCC sub contexts
- Fix test helpers to handle new audience format