### PR TITLE
Change over submission index to tiles

### DIFF
--- a/assets/css/app/_base.scss
+++ b/assets/css/app/_base.scss
@@ -538,3 +538,14 @@ form {
 .review-logo {
   max-height: 200px;
 }
+
+/* rich text editor (submission show) */
+
+.ql-editor {
+  padding: 0 7.5px;
+
+  p {
+    padding: 0;
+    margin: 0;
+  }
+}

--- a/assets/css/app/index.scss
+++ b/assets/css/app/index.scss
@@ -6,3 +6,5 @@
 @import "main_sidebar";
 @import "message_center";
 @import "select2_overrides";
+@import "../public/_challenge-tile";
+@import "../public/_tile-loader";

--- a/assets/css/public/_challenge-tile.scss
+++ b/assets/css/public/_challenge-tile.scss
@@ -64,6 +64,10 @@ p {
     display: grid;
   }
 
+  .submission-wrapper {
+    padding: 1rem 0;
+  }
+
   &__title {
     font-size: 1.125rem;
     font-weight: bold;
@@ -96,6 +100,17 @@ p {
   &__date {
     font-size: .875rem;
     color: $font-color;
+  }
+
+  &__submission-info {
+    font-size: 1.125rem;
+    margin: 0;
+    color: $font-color;
+
+    .title {
+      font-weight: bold;
+      font-size: larger;
+    }
   }
 
   &.challenge-tile {

--- a/lib/challenge_gov/submissions.ex
+++ b/lib/challenge_gov/submissions.ex
@@ -43,7 +43,7 @@ defmodule ChallengeGov.Submissions do
   def all_submissible_by_submitter_id(user_id, opts \\ []) do
     Submission
     |> base_preload
-    |> preload([:phase])
+    |> preload([:phase, challenge: [:phases]])
     |> where([s], is_nil(s.deleted_at))
     |> where([s], s.submitter_id == ^user_id)
     |> where(
@@ -58,7 +58,7 @@ defmodule ChallengeGov.Submissions do
   def all_unreviewed_by_submitter_id(user_id, opts \\ []) do
     Submission
     |> base_preload
-    |> preload([:phase])
+    |> preload([:phase, challenge: [:phases]])
     |> where([s], is_nil(s.deleted_at))
     |> where([s], s.submitter_id == ^user_id)
     |> where([s], not is_nil(s.manager_id))

--- a/lib/web/templates/submission/_unreviewed_submissions.html.eex
+++ b/lib/web/templates/submission/_unreviewed_submissions.html.eex
@@ -2,39 +2,36 @@
   <div class="container-fluid">
     <div class="row">
       <div class="col-md-12">
-        <div class="card">
-          <div class="table-responsive">
-            <table class="table table-striped">
-              <thead>
-                <tr>
-                  <th>ID</th>
-                  <th>Title</th>
-                  <th>Challenge</th>
-                  <th>Phase</th>
-                  <th>Status</th>
-                  <th>Actions</th>
-                </tr>
-              </thead>
-
-              <tbody>
-                <%= Enum.map @submissions, fn (submission) -> %>
-                  <tr>
-                    <td><%= submission.id %></td>
-                    <td><%= name_link(@conn, submission) %></td>
-                    <td><%= link(submission.challenge.title, to: Routes.public_challenge_details_path(@conn, :index, submission.challenge.id), target: "_blank") %></td>
-                    <td><%= submission.phase.title %></td>
-                    <td><%= status_display_name(submission) %></td>
-                    <td>
-                      <%= render Web.SubmissionView, "_actions.html", conn: @conn, user: @user, submission: submission %>
-                    </td>
-                  </tr>
-                <% end %>
-              </tbody>
-            </table>
-          </div>
+        <div class="cards">
+          <%= Enum.map @submissions, fn (submission) -> %>
+            <div class="challenge-tile card">
+              <%= link to: Routes.submission_path(@conn, :show, submission.id) do %>
+                <div class="image_wrapper">
+                  <%= img_tag(
+                    ChallengeView.logo_url(submission.challenge),
+                    alt: "Challenge logo",
+                    title: "Challenge logo",
+                    class: "w-100"
+                  ) %>
+                </div>
+                <div class="challenge-tile__text-wrapper submission-wrapper">
+                  <p class="challenge-tile__submission-info" aria-label="Challenge title">
+                    <span class="title"><%= SharedView.truncate_string(submission.challenge.title, 90) %></span>
+                  </p>
+                  <%= phase_number(submission) %>
+                  <p class="challenge-tile__submission-info" aria-label="Submission close">
+                    <span><%= close_header(submission.phase.end_date) %></span>
+                    <%= content_tag("span", submission.phase.end_date, class: "js-local-datetime") %>
+                  </p>
+                  <p class="challenge-tile__submission-info" aria-label="Submission status">
+                    <span>review required</span>
+                  </p>
+                </div>
+              <% end %>
+            </div>
+          <% end %>
         </div>
       </div>
     </div>
-    <%= SharedView.pagination(path: Routes.submission_path(@conn, :index), pagination: @pagination) %>
   </div>
 </section>

--- a/lib/web/templates/submission/index.html.eex
+++ b/lib/web/templates/submission/index.html.eex
@@ -37,39 +37,34 @@
   <div class="container-fluid">
     <div class="row">
       <div class="col-md-12">
-        <div class="card">
-          <div class="table-responsive">
-            <table class="table table-striped">
-              <thead>
-                <tr>
-                  <%= sortable_header(@conn, @sort, @filter, "id", "ID") %>
-                  <%= sortable_header(@conn, @sort, @filter, "title", "Name") %>
-                  <%= sortable_header(@conn, @sort, @filter, "challenge", "Challenge") %>
-                  <%= sortable_header(@conn, @sort, @filter, "phase", "Phase") %>
-                  <%= sortable_header(@conn, @sort, @filter, "status", "Status") %>
-                  <%= if Accounts.has_admin_access?(@user) do %>
-                    <th>Submitter</th>
-                  <% end %>
-                  <th>Actions</th>
-                </tr>
-              </thead>
-
-              <tbody>
-                <%= Enum.map @submissions, fn (submission) -> %>
-                  <tr>
-                    <td><%= submission.id %></td>
-                    <td><%= name_link(@conn, submission) %></td>
-                    <td><%= link(submission.challenge.title, to: Routes.public_challenge_details_path(@conn, :index, submission.challenge.id), target: "_blank") %></td>
-                    <td><%= submission.phase.title %></td>
-                    <td><%= status_display_name(submission) %></td>
-                    <td>
-                      <%= render Web.SubmissionView, "_actions.html", conn: @conn, user: @user, submission: submission %>
-                    </td>
-                  </tr>
-                <% end %>
-              </tbody>
-            </table>
-          </div>
+        <div class="cards">
+          <%= Enum.map @submissions, fn (submission) -> %>
+            <div class="challenge-tile card">
+              <%= link to: Routes.submission_path(@conn, :show, submission.id) do %>
+                <div class="image_wrapper">
+                  <%= img_tag(
+                    ChallengeView.logo_url(submission.challenge),
+                    alt: "Challenge logo",
+                    title: "Challenge logo",
+                    class: "w-100"
+                  ) %>
+                </div>
+                <div class="challenge-tile__text-wrapper submission-wrapper">
+                  <p class="challenge-tile__submission-info" aria-label="Challenge title">
+                    <span class="title"><%= SharedView.truncate_string(submission.challenge.title, 90) %></span>
+                  </p>
+                  <%= phase_number(submission) %>
+                  <p class="challenge-tile__submission-info" aria-label="Submission close">
+                    <span><%= close_header(submission.phase.end_date) %></span>
+                    <span class="js-local-datetime"><%= submission.phase.end_date %></span>
+                  </p>
+                  <p class="challenge-tile__submission-info" aria-label="Submission status">
+                    <span><%= submission.status %></span>
+                  </p>
+                </div>
+              <% end %>
+            </div>
+          <% end %>
         </div>
       </div>
     </div>

--- a/lib/web/templates/submission/show.html.eex
+++ b/lib/web/templates/submission/show.html.eex
@@ -39,11 +39,11 @@
             </div>
             <div class="form-group">
               <label class="col"><strong>Brief description:</strong></label>
-              <div class="col"><%= SharedView.render_safe_html(@submission.brief_description) %></div>
+              <div class="col ql-editor"><%= SharedView.render_safe_html(@submission.brief_description) %></div>
             </div>
             <div class="form-group">
               <label class="col"><strong>Description:</strong></label>
-              <div class="col"><%= SharedView.render_safe_html(@submission.description) %></div>
+              <div class="col ql-editor"><%= SharedView.render_safe_html(@submission.description) %></div>
             </div>
             <%= if @submission.external_url do %>
               <div class="form-group">
@@ -84,13 +84,12 @@
               <div class="col"><%= SharedView.local_datetime_tag(@submission.updated_at) %></div>
             </div>
 
-            <%= if @submission.submitter.id == @user.id or @submission.manager_id == @user.id  do %>
-              <%= link("Edit", to: Routes.submission_path(@conn, :edit, @submission.id), class: "btn btn-link float-right") %>
+            <%= submission_delete_link(@conn, @submission, @user, label: "Delete") %>
+            <%= submission_edit_link(@conn, @submission, @user, label: "Edit") %>
 
-              <%= if @submission.status !== "submitted" do %>
-                <%= link("Submit", to: Routes.submission_path(@conn, :submit, @submission.id), method: :put, class: "btn btn-primary float-right") %>
-              <% end %>
-            <% end %>              
+            <%= if @submission.status !== "submitted" do %>
+              <%= link("Submit", to: Routes.submission_path(@conn, :submit, @submission.id), method: :put, class: "btn btn-primary float-right") %>
+            <% end %>
           </section>
         </div>
         <%= if Accounts.has_admin_access?(@user) do %>

--- a/lib/web/views/shared_view.ex
+++ b/lib/web/views/shared_view.ex
@@ -4,6 +4,18 @@ defmodule Web.SharedView do
   alias Stein.Storage
   alias Web.SharedView
 
+  def truncate_string(string, len) do
+    string_length = String.length(string)
+
+    if string_length <= len do
+      string
+    else
+      overage = string_length - len
+      truncated_string = String.slice(string, (len + 1)..overage)
+      truncated_string <> "..."
+    end
+  end
+
   def session_timeout(conn) do
     Map.get(conn.private.plug_session, "session_timeout_at")
   end


### PR DESCRIPTION
submission_view.ex
* add edit helper with conditional check
* add right positioning to delete btn
* tile display helpers: close wording, phase number

shared_view.ex
* truncate string helper

submission/show.html.eex
* add ql-editor class to html from rich text editor
* remove conditional from template and into view helper

submission/index.html.eex, submission/_unreviewed_submissions.html.eex
* replace index with tiles
* remove pagination

submissions.ex
* add preloading of challenge phases for calc phase num of total

_challenge-tile.scss
* submission specific customizations different from /public tiles

app/index.scss
* add tile css to elixir side

app/_base.scss
* set editor base css to match other form data display
* remove padding from default p tag from editor text

- [ ] README is up to date
- [ ] Docs are up to date with changes (modules and functions)
- [ ] Tests are included for changes
- [ ] Links in emails use the `_url` route helpers
- [ ] Controllers modified contain appropriate authorization plugs
