### PR TITLE
Updates for solver submissions

### DIFF
--- a/assets/css/app/_base.scss
+++ b/assets/css/app/_base.scss
@@ -539,13 +539,15 @@ form {
   max-height: 200px;
 }
 
-/* rich text editor (submission show) */
+/* rich text editor reset for default p tag */
 
-.ql-editor {
-  padding: 0 7.5px;
+  /* (submission show) */
 
-  p {
-    padding: 0;
-    margin: 0;
+  .editor-text-reset {
+    padding: 0 7.5px;
+
+    p {
+      padding: 0;
+      margin: 0;
+    }
   }
-}

--- a/lib/web/templates/submission/index.html.eex
+++ b/lib/web/templates/submission/index.html.eex
@@ -55,7 +55,7 @@
                   </p>
                   <%= phase_number(submission) %>
                   <p class="challenge-tile__submission-info" aria-label="Submission close">
-                    <span><%= close_header(submission.phase.end_date) %></span>
+                    <%= close_header(submission.phase.end_date) %>
                     <span class="js-local-datetime"><%= submission.phase.end_date %></span>
                   </p>
                   <p class="challenge-tile__submission-info" aria-label="Submission status">

--- a/lib/web/templates/submission/show.html.eex
+++ b/lib/web/templates/submission/show.html.eex
@@ -39,11 +39,11 @@
             </div>
             <div class="form-group">
               <label class="col"><strong>Brief description:</strong></label>
-              <div class="col ql-editor"><%= SharedView.render_safe_html(@submission.brief_description) %></div>
+              <div class="col ql-editor editor-text-reset"><%= SharedView.render_safe_html(@submission.brief_description) %></div>
             </div>
             <div class="form-group">
               <label class="col"><strong>Description:</strong></label>
-              <div class="col ql-editor"><%= SharedView.render_safe_html(@submission.description) %></div>
+              <div class="col ql-editor editor-text-reset"><%= SharedView.render_safe_html(@submission.description) %></div>
             </div>
             <%= if @submission.external_url do %>
               <div class="form-group">
@@ -86,10 +86,8 @@
 
             <%= submission_delete_link(@conn, @submission, @user, label: "Delete") %>
             <%= submission_edit_link(@conn, @submission, @user, label: "Edit") %>
+            <%= submit_button(@conn, @submission, @user, label: "Submit") %>
 
-            <%= if @submission.status !== "submitted" do %>
-              <%= link("Submit", to: Routes.submission_path(@conn, :submit, @submission.id), method: :put, class: "btn btn-primary float-right") %>
-            <% end %>
           </section>
         </div>
         <%= if Accounts.has_admin_access?(@user) do %>

--- a/lib/web/views/submission_view.ex
+++ b/lib/web/views/submission_view.ex
@@ -62,10 +62,10 @@ defmodule Web.SubmissionView do
 
     case Timex.compare(end_date, now) do
       1 ->
-        "Closes"
+        content_tag(:span, "Closes")
 
       tc when tc == -1 or tc == 0 ->
-        "CLOSED"
+        content_tag(:span, "CLOSED", class: "text-bold")
     end
   end
 
@@ -186,6 +186,20 @@ defmodule Web.SubmissionView do
         link(opts[:label] || "Edit",
           to: Routes.submission_path(conn, :edit, submission.id),
           class: "btn btn-link float-right"
+        )
+
+      false ->
+        nil
+    end
+  end
+
+  def submit_button(conn, submission, user, opts \\ []) do
+    case Submissions.is_editable?(user, submission) && submission.status !== "submitted" do
+      true ->
+        link(opts[:label] || "Submit",
+          to: Routes.submission_path(conn, :submit, submission.id),
+          method: :put,
+          class: "btn btn-primary float-right"
         )
 
       false ->

--- a/test/integration/submission_test.exs
+++ b/test/integration/submission_test.exs
@@ -24,11 +24,9 @@ defmodule ChallengeGov.SubmissionTest do
     |> click(link("Submit"))
     |> assert_text("Submission saved")
 
-    submission_id = get_submission_id(session)
-
     session
     |> click(link("< Back to submissions"))
-    |> assert_text("#{submission_id}")
+    |> assert_text("#{challenge.title}")
   end
 
   feature "create a submission as an admin", %{session: session} do


### PR DESCRIPTION
submission_view.ex
* move submit button & conditions into helper, add is_editable condition
to account for if the phase is still open
* make CLOSED bold

submission/show.html.eex
* updates to submit button removal
* add rich text editor css resetting selector

submission/index.html.eex
* close text parent tag moved to helper

_base.scss
* move rich text reset css to a different selector

submission_test.exs
* update browser test in accordance with tile display

- [ ] README is up to date
- [ ] Docs are up to date with changes (modules and functions)
- [ ] Tests are included for changes
- [ ] Links in emails use the `_url` route helpers
- [ ] Controllers modified contain appropriate authorization plugs
