### PR TITLE
Chal 674/follow a challenge

### DIFF
--- a/assets/css/app/_base.scss
+++ b/assets/css/app/_base.scss
@@ -545,3 +545,9 @@ form {
       margin: 0;
     }
   }
+
+  /* flash messages */
+
+  .flash-icon {
+    margin-right: .5em;
+  }

--- a/lib/challenge_gov/accounts.ex
+++ b/lib/challenge_gov/accounts.ex
@@ -360,14 +360,15 @@ defmodule ChallengeGov.Accounts do
         case get_by_email(userinfo["email"]) do
           {:error, :not_found} ->
             %{"email" => email} = userinfo
+            {role, status} = default_role_and_status_for_email(email)
 
             create(remote_ip, %{
               email: email,
-              role: default_role_for_email(email),
+              role: role,
               token: userinfo["sub"],
               terms_of_use: nil,
               privacy_guidelines: nil,
-              status: "pending"
+              status: status
             })
 
           {:ok, user} ->
@@ -389,13 +390,13 @@ defmodule ChallengeGov.Accounts do
     end
   end
 
-  defp default_role_for_email(email) do
+  defp default_role_and_status_for_email(email) do
     case Security.default_challenge_owner?(email) do
       true ->
-        "challenge_owner"
+        {"challenge_owner", "pending"}
 
       false ->
-        "solver"
+        {"solver", "active"}
     end
   end
 

--- a/lib/web/controllers/challenge_controller.ex
+++ b/lib/web/controllers/challenge_controller.ex
@@ -222,7 +222,7 @@ defmodule Web.ChallengeController do
 
         "return_to_review" ->
           conn
-          |> put_flash(:info, "changes saved")
+          |> put_flash(:info, "Changes saved")
           |> redirect(to: Routes.challenge_path(conn, :show, challenge.id) <> "##{section}")
 
         "submit" ->
@@ -468,12 +468,31 @@ defmodule Web.ChallengeController do
 
     conn
     |> put_flash(:warning, [
-      content_tag(:span, "Challenge Removed from Queue", class: "h4"),
-      content_tag(:br, ""),
-      "Once edits are made you will need to resubmit this challenge for GSA approval"
+      content_tag(:p, "Challenge Removed from Queue", class: "h4 mb-0"),
+      content_tag(
+        :p,
+        "Once edits are made you will need to resubmit this challenge for GSA approval"
+      )
     ])
     |> assign(:challenge, challenge)
   end
 
   defp maybe_reset_challenge_status(conn, _user, _challenge), do: conn
+
+  defp maybe_put_flash_subscriber_update(conn, challenge) do
+    case challenge.status do
+      "published" ->
+        conn
+        |> put_flash(:info, [
+          content_tag(:span, "Challenge updated", class: "h4 mb-0"),
+          content_tag(
+            :p,
+            "Please share critical updates with Solvers that have saved this challenge <<link: GovDelivery>>"
+          )
+        ])
+
+      _ ->
+        conn
+    end
+  end
 end

--- a/lib/web/controllers/challenge_controller.ex
+++ b/lib/web/controllers/challenge_controller.ex
@@ -223,6 +223,7 @@ defmodule Web.ChallengeController do
         "return_to_review" ->
           conn
           |> put_flash(:info, "Changes saved")
+          |> maybe_put_flash_subscriber_update(challenge)
           |> redirect(to: Routes.challenge_path(conn, :show, challenge.id) <> "##{section}")
 
         "submit" ->
@@ -242,6 +243,7 @@ defmodule Web.ChallengeController do
               ") with your question and Challenge ID number #{challenge.id}."
             ]
           )
+          |> maybe_put_flash_subscriber_update(challenge)
           |> redirect(to: Routes.challenge_path(conn, :show, challenge.id))
 
         _ ->
@@ -484,10 +486,13 @@ defmodule Web.ChallengeController do
       "published" ->
         conn
         |> put_flash(:info, [
-          content_tag(:span, "Challenge updated", class: "h4 mb-0"),
+          content_tag(:p, "Challenge updated", class: "h4 mb-0"),
           content_tag(
             :p,
-            "Please share critical updates with Solvers that have saved this challenge <<link: GovDelivery>>"
+            [
+              "Please share critical updates with Solvers that have saved this challenge ",
+              link("Govdelivery", to: Routes.challenge_bulletin_path(conn, :new, challenge.id))
+            ]
           )
         ])
 

--- a/lib/web/templates/layout/app.html.eex
+++ b/lib/web/templates/layout/app.html.eex
@@ -132,8 +132,8 @@
         <%= if get_flash(@conn, :info) do %>
           <div class="content-header">
             <div class="container-fluid">
-              <div class="callout callout-success">
-                <i class="fa fa-info-circle"></i> <%= get_flash(@conn, :info) %>
+              <div class="callout callout-success d-flex align-items-center">
+                <i class="fa fa-check-circle h4 mb-0 flash-icon"></i><span><%= get_flash(@conn, :info) %></span>
               </div>
             </div>
           </div>
@@ -142,8 +142,8 @@
         <%= if get_flash(@conn, :error) do %>
           <div class="content-header">
             <div class="container-fluid">
-              <div class="callout callout-danger">
-                <i class="fa fa-exclamation-circle"></i> <%= get_flash(@conn, :error) %>
+              <div class="callout callout-danger d-flex align-items-center">
+                <i class="fa fa-exclamation-circle h4 mb-0 flash-icon"></i><span><%= get_flash(@conn, :error) %></span>
               </div>
             </div>
           </div>
@@ -152,8 +152,8 @@
         <%= if get_flash(@conn, :warning) do %>
           <div class="content-header">
             <div class="container-fluid">
-              <div class="callout callout-warning">
-                <i class="fa fa-exclamation-circle"></i> <%= get_flash(@conn, :warning) %>
+              <div class="callout callout-warning d-flex align-items-center">
+                <i class="fa fa-exclamation-circle h4 mb-0 flash-icon"></i><span><%= get_flash(@conn, :warning) %></span>
               </div>
             </div>
           </div>

--- a/test/web/controllers/challenge_controller_test.exs
+++ b/test/web/controllers/challenge_controller_test.exs
@@ -432,9 +432,6 @@ defmodule Web.ChallengeControllerTest do
     end
 
     test "successfully update a published challenge", %{conn: conn} do
-      # change something
-      # return to review
-      # still published
       conn = prep_conn_challenge_owner(conn)
       %{current_user: user} = conn.assigns
 
@@ -486,7 +483,44 @@ defmodule Web.ChallengeControllerTest do
 
       assert challenge.status === "published"
       assert challenge.poc_email === "new_poc@example.com"
-      assert get_flash(conn, :info) === "changes saved"
+      assert get_flash(conn, :info) ===
+               [
+                 safe: [
+                   60,
+                   "p",
+                   [[32, "class", 61, 34, "h4 mb-0", 34]],
+                   62,
+                   "Challenge updated",
+                   60,
+                   47,
+                   "p",
+                   62
+                 ],
+                 safe: [
+                   60,
+                   "p",
+                   [],
+                   62,
+                   [
+                     "Please share critical updates with Solvers that have saved this challenge ",
+                     [
+                       60,
+                       "a",
+                       [[32, "href", 61, 34, "/challenges/#{challenge.id}/bulletin/new", 34]],
+                       62,
+                       "Govdelivery",
+                       60,
+                       47,
+                       "a",
+                       62
+                     ]
+                   ],
+                   60,
+                   47,
+                   "p",
+                   62
+                 ]
+               ]
 
       assert redirected_to(conn) ===
                Routes.challenge_path(conn, :show, challenge.id) <> "#general"

--- a/test/web/controllers/challenge_controller_test.exs
+++ b/test/web/controllers/challenge_controller_test.exs
@@ -250,17 +250,27 @@ defmodule Web.ChallengeControllerTest do
                  {:safe,
                   [
                     60,
-                    "span",
-                    [[32, "class", 61, 34, "h4", 34]],
+                    "p",
+                    [[32, "class", 61, 34, "h4 mb-0", 34]],
                     62,
                     "Challenge Removed from Queue",
                     60,
                     47,
-                    "span",
+                    "p",
                     62
                   ]},
-                 {:safe, [60, "br", [], 62, [], 60, 47, "br", 62]},
-                 "Once edits are made you will need to resubmit this challenge for GSA approval"
+                 {:safe,
+                  [
+                    60,
+                    "p",
+                    [],
+                    62,
+                    "Once edits are made you will need to resubmit this challenge for GSA approval",
+                    60,
+                    47,
+                    "p",
+                    62
+                  ]}
                ]
     end
 
@@ -379,7 +389,7 @@ defmodule Web.ChallengeControllerTest do
 
       assert challenge.status === "draft"
       assert challenge.poc_email === "new_poc@example.com"
-      assert get_flash(conn, :info) === "changes saved"
+      assert get_flash(conn, :info) === "Changes saved"
 
       assert redirected_to(conn) ===
                Routes.challenge_path(conn, :show, challenge.id) <> "#general"
@@ -483,6 +493,7 @@ defmodule Web.ChallengeControllerTest do
 
       assert challenge.status === "published"
       assert challenge.poc_email === "new_poc@example.com"
+
       assert get_flash(conn, :info) ===
                [
                  safe: [


### PR DESCRIPTION
### Changes
Change default status for new solvers to 'active'
Add new flash message on saving published challenge edits with gov delivery reminder
update flash message styling

- [ ] README is up to date
- [ ] Docs are up to date with changes (modules and functions)
- [ ] Tests are included for changes
- [ ] Links in emails use the `_url` route helpers
- [ ] Controllers modified contain appropriate authorization plugs
