### PR TITLE
Chal 577 - non .mil / .gov challenge manager changes

### DIFF
--- a/lib/challenge_gov/accounts.ex
+++ b/lib/challenge_gov/accounts.ex
@@ -26,7 +26,7 @@ defmodule ChallengeGov.Accounts do
         User.roles()
 
       "admin" ->
-        Enum.slice(User.roles(), 2..2)
+        Enum.slice(User.roles(), 2..3)
     end
   end
 

--- a/lib/challenge_gov/challenges.ex
+++ b/lib/challenge_gov/challenges.ex
@@ -20,6 +20,7 @@ defmodule ChallengeGov.Challenges do
   alias ChallengeGov.Phases
   alias ChallengeGov.Repo
   alias ChallengeGov.SavedChallenges
+  alias ChallengeGov.Security
   alias ChallengeGov.SecurityLogs
   alias ChallengeGov.SupportingDocuments
   alias ChallengeGov.Timeline.Event
@@ -696,6 +697,16 @@ defmodule ChallengeGov.Challenges do
       {:error, :not_permitted} -> false
     end
   end
+
+  def allowed_to_submit?(%{role: "super_admin"}), do: true
+
+  def allowed_to_submit?(%{role: "admin"}), do: true
+
+  def allowed_to_submit?(user = %{role: "challenge_owner"}) do
+    Security.default_challenge_owner?(user.email)
+  end
+
+  def allowed_to_submit?(_user), do: false
 
   @doc """
   Checks if a user can send a bulletin

--- a/lib/web/controllers/user_controller.ex
+++ b/lib/web/controllers/user_controller.ex
@@ -7,8 +7,12 @@ defmodule Web.UserController do
   alias ChallengeGov.Repo
   alias ChallengeGov.Security
 
-  plug(Web.Plugs.EnsureRole, [:super_admin, :admin] when action in [:index, :show, :toggle])
-  plug(Web.Plugs.EnsureRole, :super_admin when action not in [:index, :show, :toggle])
+  plug(
+    Web.Plugs.EnsureRole,
+    [:super_admin, :admin] when action in [:index, :show, :edit, :update, :toggle]
+  )
+
+  plug(Web.Plugs.EnsureRole, :super_admin when action in [:create])
   plug(Web.Plugs.FetchPage when action in [:index, :create])
 
   def index(conn, params) do

--- a/lib/web/templates/challenge/_challenge_manager_banner.html.eex
+++ b/lib/web/templates/challenge/_challenge_manager_banner.html.eex
@@ -1,0 +1,13 @@
+<%= if !Challenges.allowed_to_submit?(@user) do %>
+  <div class="content-header">
+    <div class="container-fluid">
+      <div class="callout callout-warning d-flex align-items-center">
+        <i class="fa fa-exclamation-circle h4 mb-0 flash-icon"></i>
+        <span>
+          <p class="h4 mb-0">Please note a Challenge Manager with a .gov or .mil email will need to submit</p>
+          <p>You will only be able to save and edit this challenge, your edits will not be submitted</p>
+        </span>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/lib/web/templates/challenge/show.html.eex
+++ b/lib/web/templates/challenge/show.html.eex
@@ -5,6 +5,7 @@
       %{text: "Challenges", route: Routes.challenge_path(@conn, :index)},
       %{text: @challenge.title}
     ])%>
+    <%= render Web.ChallengeView, "_challenge_manager_banner.html", user: @user %>
     <div class="row">
       <div class="col-sm-6">
         <h1 class="m-0 text-dark">

--- a/lib/web/templates/challenge/wizard.html.eex
+++ b/lib/web/templates/challenge/wizard.html.eex
@@ -5,6 +5,7 @@
       %{text: "Challenges", route: Routes.challenge_path(@conn, :index)},
       %{text: "New"},
     ])%>
+    <%= render Web.ChallengeView, "_challenge_manager_banner.html", user: @user %>
     <div class="row mb-2">
       <div class="col-sm-6">
         <h1 class="m-0 text-dark">
@@ -63,7 +64,7 @@
                 <% end %>
                 <%= save_and_return_to_review_button(@conn, @challenge) %>
                 <%= cancel_button(@conn) %>
-                <%= submit_button(@section) %>
+                <%= submit_button(@section, @user) %>
                 <%= preview_challenge_button(@conn, @challenge, @section) %>
                 <%= save_draft_button(@section) %>
               </div>

--- a/lib/web/templates/user/index.html.eex
+++ b/lib/web/templates/user/index.html.eex
@@ -45,7 +45,7 @@
                     <td><%= user.status %></td>
                     <td>
                       <%= link("View", to: Routes.user_path(@conn, :show, user.id), class: "btn btn-default btn-xs") %>
-                      <%= link("Edit", to: Routes.user_path(@conn, :edit, user.id), class: "btn btn-default btn-xs") %>
+                      <%= user_edit_link(@conn, user, @current_user) %>
                     </td>
                   </tr>
                 <% end %>

--- a/lib/web/views/challenge_view.ex
+++ b/lib/web/views/challenge_view.ex
@@ -479,11 +479,13 @@ defmodule Web.ChallengeView do
     end
   end
 
-  def submit_button(section) do
-    if section == Enum.at(Challenges.sections(), -1).id do
-      submit("Submit", name: "action", value: "submit", class: "usa-button float-right")
-    else
-      submit("Next", name: "action", value: "next", class: "usa-button float-right")
+  def submit_button(section, user) do
+    if Challenges.allowed_to_submit?(user) do
+      if section == Enum.at(Challenges.sections(), -1).id do
+        submit("Submit", name: "action", value: "submit", class: "usa-button float-right")
+      else
+        submit("Next", name: "action", value: "next", class: "usa-button float-right")
+      end
     end
   end
 

--- a/lib/web/views/user_view.ex
+++ b/lib/web/views/user_view.ex
@@ -26,6 +26,32 @@ defmodule Web.UserView do
     end
   end
 
+  def user_edit_link(conn, user, current_user = %{role: "super_admin"}) do
+    case Accounts.get_role_rank(current_user.role) > Accounts.get_role_rank(user.role) do
+      true ->
+        nil
+
+      false ->
+        link("Edit",
+          to: Routes.user_path(conn, :edit, user.id),
+          class: "btn btn-default btn-xs"
+        )
+    end
+  end
+
+  def user_edit_link(conn, user, current_user = %{role: "admin"}) do
+    case Accounts.get_role_rank(current_user.role) >= Accounts.get_role_rank(user.role) do
+      true ->
+        nil
+
+      false ->
+        link("Edit",
+          to: Routes.user_path(conn, :edit, user.id),
+          class: "btn btn-default btn-xs"
+        )
+    end
+  end
+
   def certification_info(certification) do
     now = Timex.to_unix(Timex.now())
     expiration_date = certification.expires_at


### PR DESCRIPTION
Bar non .mil / .gov challenge managers from submitting a challenge + add info banner

user_view.ex
* edit button helper: show dependant on role and user

challenge_view.ex
* add allowed to submit conditional to show submit button

user/index.html.eex
* turn edit button into a helper with conditionals

wizard.html.eex
* add user attr to submit btn helper
* add manager banner

challenge/show.html.eex
* add manager banner

_challenge_manager_banner.html.eex
* info banner for non .mil / .gov managers that they can't submit

user_controller.ex
* allow admins to edit and update users

challenges.ex
* allowed_to_submit fn

accounts.ex
* allow admins access to solver and challenge owner roles when editing

- [ ] README is up to date
- [ ] Docs are up to date with changes (modules and functions)
- [ ] Tests are included for changes
- [ ] Links in emails use the `_url` route helpers
- [ ] Controllers modified contain appropriate authorization plugs
