### PR TITLE
Clean slate - adding header and custom body to gov delivery emails

### DIFF
--- a/assets/js/app/_rich_text_editor.js
+++ b/assets/js/app/_rich_text_editor.js
@@ -33,13 +33,7 @@ let toolbarOptions = [
 ]
 
 $(".rt-textarea").each(function(textarea) {
-  var SizeStyle = Quill.import('attributors/style/size');
-  // var IndentStyle = Quill.import('attributors/style/indent');
-  Quill.register(SizeStyle, true);
-  // Quill.register(IndentStyle, true);
-
   let element = this
-
   let quill = new Quill(element, {
     theme: 'snow',
     placeholder: "Enter text...",

--- a/lib/challenge_gov/gov_delivery/implementation.ex
+++ b/lib/challenge_gov/gov_delivery/implementation.ex
@@ -308,16 +308,8 @@ defmodule ChallengeGov.GovDelivery.Implementation do
 
     customized_body = render_to_string(Web.BulletinView, "body.html", body: body)
 
-    header_img =
-      {:img,
-       %{
-         src: Routes.static_path(Endpoint, "/images/email-header.png"),
-         alt: "Challenge.Gov logo",
-         title: "Challenge.Gov logo"
-       }, nil}
-
     elements = [
-      {:header, nil, [header_img]},
+      {:header, nil, Routes.static_url(Endpoint, "/images/email-header.png")},
       {:subject, nil, subject},
       {:body, nil, {:cdata, customized_body}},
       {:topics, %{type: "array"}, challenge_topic}

--- a/lib/web/templates/bulletin/body.html.eex
+++ b/lib/web/templates/bulletin/body.html.eex
@@ -162,11 +162,7 @@
 											<!--[if mso]><table width="100%" cellpadding="0" cellspacing="0" border="0"><tr><td style="padding-right: 0px; padding-left: 0px; padding-top: 20px; padding-bottom: 20px; font-family: Arial, sans-serif"><![endif]-->
 											<div style="color:#393d47;font-family:Arial, Helvetica Neue, Helvetica, sans-serif;line-height:1.2;padding-top:20px;padding-right:0px;padding-bottom:20px;padding-left:0px;">
 												<div class="txtTinyMce-wrapper" style="font-size: 14px; line-height: 1.2; color: #393d47; font-family: Arial, Helvetica Neue, Helvetica, sans-serif; mso-line-height-alt: 17px;">
-												  <div class="box-sizing: border-box; line-height: 1.42; height: 100%; outline: none; overflow-y: auto; padding: 12px 15px; tab-size: 4; -moz-tab-size: 4; text-align: left; white-space: pre-wrap; word-wrap: break-word;">
-														<span style="padding: 12px">
-															<%= @body %>
-														</span>
-													</div>
+													<%= SharedView.render_safe_html(@body) %>
 												</div>
 											</div>
 											<!--[if mso]></td></tr></table><![endif]-->


### PR DESCRIPTION
_rich_text_editor.js
* clear out inline quill styling

implementation.ex
* update header image url

body.html.eex
* use SharedView.render_safe_html on custom body

- [ ] README is up to date
- [ ] Docs are up to date with changes (modules and functions)
- [ ] Tests are included for changes
- [ ] Links in emails use the `_url` route helpers
- [ ] Controllers modified contain appropriate authorization plugs
