### PR TITLE
CHAL-706/limit-file-uploads-by-type

### DIFF
--- a/assets/js/app/_phase_winners_file_upload.js
+++ b/assets/js/app/_phase_winners_file_upload.js
@@ -5,11 +5,16 @@ $.ajaxPrefilter(function (options, originalOptions, jqXHR) {
 });
 
 $(".winners-overview").on("change", "#phase_winner_overview_image", (e) => {
+  $(e.target).removeClass("is-invalid")
+})
+
+$(".winners-overview").on("change", "#phase_winner_overview_image", (e) => {
   form = e.target.form
   phaseWinnerId = $(form).data("phase-winner-id")
   formGroup = e.target.closest(".form-group")
 
-  file = $(e.target).prop("files")[0]
+  fileInput = $(e.target)
+  file = fileInput.prop("files")[0]
 
   fd = new FormData()
   fd.append("overview_image", file)
@@ -27,6 +32,7 @@ $(".winners-overview").on("change", "#phase_winner_overview_image", (e) => {
       },
       error: function(err) {
         console.log("Something went wrong", err)
+        $(fileInput).addClass("is-invalid")
       }
     })
   }

--- a/assets/js/app/_section_file_upload.js
+++ b/assets/js/app/_section_file_upload.js
@@ -4,6 +4,10 @@ $.ajaxPrefilter(function (options, originalOptions, jqXHR) {
   jqXHR.setRequestHeader('X-CSRF-Token', csrf_token);
 });
 
+$(".challenge-file-upload").on("change", ".challenge_document_file", function() {
+  $(this).removeClass("is-invalid")
+})
+
 $(".challenge-file-upload").on("click", ".challenge_document_upload", function() {
   parentComponent = $(this).parents(".challenge-file-upload")
 
@@ -46,6 +50,7 @@ $(".challenge-file-upload").on("click", ".challenge_document_upload", function()
       },
       error: function(err) {
         console.log("Something went wrong")
+        $(fileInput).addClass("is-invalid")
       }
     })
   }

--- a/assets/js/app/_submission_file_upload.js
+++ b/assets/js/app/_submission_file_upload.js
@@ -4,6 +4,10 @@ $.ajaxPrefilter(function (options, originalOptions, jqXHR) {
   jqXHR.setRequestHeader('X-CSRF-Token', csrf_token);
 });
 
+$("#submission_document").on("change", function() {
+  $(this).removeClass("is-invalid")
+})
+
 $("#submission_document_upload").on("click", function(e) {
   name_input = $("#submission_document_name")
   name = name_input.val()
@@ -45,7 +49,11 @@ $("#submission_document_upload").on("click", function(e) {
       },
       error: function(err) {
         console.log("Something went wrong")
-        handleFileUploadError(err.responseJSON.errors)
+        if(err["solver_addr"]) {
+          handleFileUploadError(err.responseJSON.errors)
+        } else {
+          $(file_input).addClass("is-invalid")
+        }
       }
     })
   }

--- a/lib/challenge_gov/phase_winners.ex
+++ b/lib/challenge_gov/phase_winners.ex
@@ -149,7 +149,9 @@ defmodule ChallengeGov.PhaseWinners do
     path = overview_image_path(phase_winner, key, file.extension)
     meta = [{:content_disposition, ~s{attachment; filename="#{file.filename}"}}]
 
-    case Storage.upload(file, path, meta: meta) do
+    allowed_extensions = [".jpg", ".jpeg", ".png", ".gif"]
+
+    case Storage.upload(file, path, meta: meta, extensions: allowed_extensions) do
       :ok ->
         {:ok, key, file.extension}
 

--- a/lib/challenge_gov/submission_documents.ex
+++ b/lib/challenge_gov/submission_documents.ex
@@ -49,7 +49,9 @@ defmodule ChallengeGov.SubmissionDocuments do
       {:content_disposition, ~s{attachment; filename="#{file.filename}"}}
     ]
 
-    case Storage.upload(file, path, meta: meta) do
+    allowed_extensions = [".pdf", ".txt", ".csv", ".jpg", ".png", ".tiff"]
+
+    case Storage.upload(file, path, meta: meta, extensions: allowed_extensions) do
       :ok ->
         user
         |> Ecto.build_assoc(:submission_documents)

--- a/lib/challenge_gov/supporting_documents.ex
+++ b/lib/challenge_gov/supporting_documents.ex
@@ -54,7 +54,9 @@ defmodule ChallengeGov.SupportingDocuments do
       {:content_disposition, ~s{attachment; filename="#{file.filename}"}}
     ]
 
-    case Storage.upload(file, path, meta: meta) do
+    allowed_extensions = [".pdf", ".txt", ".csv", ".jpg", ".png", ".tiff"]
+
+    case Storage.upload(file, path, meta: meta, extensions: allowed_extensions) do
       :ok ->
         user
         |> Ecto.build_assoc(:supporting_documents)

--- a/lib/challenge_gov/winners.ex
+++ b/lib/challenge_gov/winners.ex
@@ -54,7 +54,9 @@ defmodule ChallengeGov.Winners do
     path = image_path(phase_winner, key, file.extension)
     meta = [{:content_disposition, ~s{attachment; filename="#{file.filename}"}}]
 
-    case Storage.upload(file, path, meta: meta) do
+    allowed_extensions = [".jpg", ".jpeg", ".png", ".gif"]
+
+    case Storage.upload(file, path, meta: meta, extensions: allowed_extensions) do
       :ok ->
         phase_winner
         |> Winner.image_changeset(key, file.extension)

--- a/lib/web/controllers/api/document_controller.ex
+++ b/lib/web/controllers/api/document_controller.ex
@@ -3,6 +3,7 @@ defmodule Web.Api.DocumentController do
 
   alias ChallengeGov.Challenges
   alias ChallengeGov.SupportingDocuments
+  alias Web.ErrorView
 
   action_fallback(Web.FallbackController)
 
@@ -20,6 +21,12 @@ defmodule Web.Api.DocumentController do
       |> put_status(:ok)
       |> assign(:document, document)
       |> render("show.json")
+    else
+      _error ->
+        conn
+        |> put_status(:unprocessable_entity)
+        |> put_view(ErrorView)
+        |> render("errors.json")
     end
   end
 

--- a/lib/web/controllers/phase_winner_controller.ex
+++ b/lib/web/controllers/phase_winner_controller.ex
@@ -52,6 +52,7 @@ defmodule Web.PhaseWinnerController do
         |> assign(:challenge, challenge)
         |> assign(:phase, phase)
         |> assign(:changeset, PhaseWinners.edit(phase_winner))
+        |> assign(:upload_error, false)
         |> assign(:action, Routes.phase_winner_path(conn, :update, phase.id))
         |> render("edit.html")
 
@@ -74,12 +75,25 @@ defmodule Web.PhaseWinnerController do
         {:ok, _phase_winner} = PhaseWinners.create(phase, %{"phase_winner" => %{}})
         redirect(conn, to: Routes.phase_winner_path(conn, :edit, phase.id))
 
+      {:error, :something_went_wrong} ->
+        {:ok, phase_winner} = PhaseWinners.get_by_phase_id(phase.id)
+
+        conn
+        |> assign(:user, user)
+        |> assign(:challenge, challenge)
+        |> assign(:phase, phase)
+        |> assign(:changeset, PhaseWinners.edit(phase_winner))
+        |> assign(:upload_error, true)
+        |> assign(:action, Routes.phase_winner_path(conn, :update, phase.id))
+        |> render("edit.html")
+
       {:error, changeset} ->
         conn
         |> assign(:user, user)
         |> assign(:challenge, challenge)
         |> assign(:phase, phase)
         |> assign(:changeset, changeset)
+        |> assign(:action, Routes.phase_winner_path(conn, :update, phase.id))
         |> render("edit.html")
     end
   end

--- a/lib/web/templates/challenge/wizard/_details.html.eex
+++ b/lib/web/templates/challenge/wizard/_details.html.eex
@@ -79,6 +79,7 @@
     <br/>
     <input class="challenge_document_file form-file-control" type="file">
     <div class="challenge_document_upload btn btn-primary">Upload file</div>
+    <div class="challenge_document_upload_error invalid-feedback">File must be a .pdf, .txt, .csv, .jpg, .png, or .tiff</div>
   </div>
 
   <br/>

--- a/lib/web/templates/challenge/wizard/_details.html.eex
+++ b/lib/web/templates/challenge/wizard/_details.html.eex
@@ -80,6 +80,7 @@
     <input class="challenge_document_file form-file-control" type="file">
     <div class="challenge_document_upload btn btn-primary">Upload file</div>
     <div class="challenge_document_upload_error invalid-feedback">File must be a .pdf, .txt, .csv, .jpg, .png, or .tiff</div>
+    <small class="form-text text-muted font-italic">Allowed file types: .pdf, .txt, .csv, .jpg, .png, or .tiff</small>
   </div>
 
   <br/>
@@ -121,6 +122,7 @@
       <div class="row logo-file-field collapse">
         <%= FormView.file_field(@form, :logo, label: "Logo", required: true) %>
       </div>
+      <small class="form-text text-muted font-italic">Allowed file types: .jpg, .jpeg, .png, .gif</small>
     </div>
     <%= if @data.logo_key do %>
       <p>Current logo:</p>

--- a/lib/web/templates/challenge/wizard/_judging.html.eex
+++ b/lib/web/templates/challenge/wizard/_judging.html.eex
@@ -21,6 +21,7 @@
     <br/>
     <input class="challenge_document_file form-file-control" type="file">
     <div class="challenge_document_upload btn btn-primary">Upload file</div>
+    <div class="challenge_document_upload_error invalid-feedback">File must be a .pdf, .txt, .csv, .jpg, .png, or .tiff</div>
   </div>              
 
   <br/>

--- a/lib/web/templates/challenge/wizard/_judging.html.eex
+++ b/lib/web/templates/challenge/wizard/_judging.html.eex
@@ -22,6 +22,7 @@
     <input class="challenge_document_file form-file-control" type="file">
     <div class="challenge_document_upload btn btn-primary">Upload file</div>
     <div class="challenge_document_upload_error invalid-feedback">File must be a .pdf, .txt, .csv, .jpg, .png, or .tiff</div>
+    <small class="form-text text-muted font-italic">Allowed file types: .pdf, .txt, .csv, .jpg, .png, or .tiff</small>
   </div>              
 
   <br/>

--- a/lib/web/templates/challenge/wizard/_resources.html.eex
+++ b/lib/web/templates/challenge/wizard/_resources.html.eex
@@ -35,6 +35,7 @@
     <br/>
     <input class="challenge_document_file form-file-control" type="file">
     <div class="challenge_document_upload btn btn-primary">Upload file</div>
+    <div class="challenge_document_upload_error invalid-feedback">File must be a .pdf, .txt, .csv, .jpg, .png, or .tiff</div>
   </div>              
 
   <br/>
@@ -62,6 +63,7 @@
     <br/>
     <input class="challenge_document_file form-file-control" type="file">
     <div class="challenge_document_upload btn btn-primary">Upload file</div>
+    <div class="challenge_document_upload_error invalid-feedback">File must be a .pdf, .txt, .csv, .jpg, .png, or .tiff</div>
   </div>              
 
   <br/>

--- a/lib/web/templates/challenge/wizard/_resources.html.eex
+++ b/lib/web/templates/challenge/wizard/_resources.html.eex
@@ -15,6 +15,7 @@
   <br/>
   <p>This image will display at the top of the resources section</p>
   <%= FormView.file_field(@form, :resource_banner, label: false) do %>
+    <small class="form-text text-muted font-italic">Allowed file types: .jpg, .jpeg, .png, .gif</small>
     <br/>
     <%= if @data.resource_banner_key do %>
       <p>Current resource banner:</p>
@@ -36,6 +37,7 @@
     <input class="challenge_document_file form-file-control" type="file">
     <div class="challenge_document_upload btn btn-primary">Upload file</div>
     <div class="challenge_document_upload_error invalid-feedback">File must be a .pdf, .txt, .csv, .jpg, .png, or .tiff</div>
+    <small class="form-text text-muted font-italic">Allowed file types: .pdf, .txt, .csv, .jpg, .png, or .tiff</small>
   </div>              
 
   <br/>
@@ -64,6 +66,7 @@
     <input class="challenge_document_file form-file-control" type="file">
     <div class="challenge_document_upload btn btn-primary">Upload file</div>
     <div class="challenge_document_upload_error invalid-feedback">File must be a .pdf, .txt, .csv, .jpg, .png, or .tiff</div>
+    <small class="form-text text-muted font-italic">Allowed file types: .pdf, .txt, .csv, .jpg, .png, or .tiff</small>
   </div>              
 
   <br/>

--- a/lib/web/templates/challenge/wizard/_rules.html.eex
+++ b/lib/web/templates/challenge/wizard/_rules.html.eex
@@ -36,6 +36,7 @@
     <input class="challenge_document_file form-file-control" type="file">
     <div class="challenge_document_upload btn btn-primary">Upload file</div>
     <div class="challenge_document_upload_error invalid-feedback">File must be a .pdf, .txt, .csv, .jpg, .png, or .tiff</div>
+    <small class="form-text text-muted font-italic">Allowed file types: .pdf, .txt, .csv, .jpg, .png, or .tiff</small>
   </div>              
 
   <br/>

--- a/lib/web/templates/challenge/wizard/_rules.html.eex
+++ b/lib/web/templates/challenge/wizard/_rules.html.eex
@@ -35,6 +35,7 @@
     <br/>
     <input class="challenge_document_file form-file-control" type="file">
     <div class="challenge_document_upload btn btn-primary">Upload file</div>
+    <div class="challenge_document_upload_error invalid-feedback">File must be a .pdf, .txt, .csv, .jpg, .png, or .tiff</div>
   </div>              
 
   <br/>

--- a/lib/web/templates/phase_winner/_form.html.eex
+++ b/lib/web/templates/phase_winner/_form.html.eex
@@ -21,7 +21,7 @@
       <div class="col individual-winners">
         <h2>Add individual winners with name, rank and photo (optional)</h2>
 
-        <%= render Web.PhaseWinnerView, "winners/_form.html", form: f %>
+        <%= render Web.PhaseWinnerView, "winners/_form.html", form: f, upload_error: @upload_error %>
       </div>
 
       <hr/>

--- a/lib/web/templates/phase_winner/_form.html.eex
+++ b/lib/web/templates/phase_winner/_form.html.eex
@@ -9,7 +9,10 @@
         <label>Winners overview image (optional)</label>
         <%= hidden_input f, :overview_image_key %>
         <%= hidden_input f, :overview_image_extension %>
-        <%= FormView.file_field(f, :overview_image, label: false) %>
+        <div class="mb-3">
+          <input class="form-control-file" id="phase_winner_overview_image" name="phase_winner[overview_image]" type="file">
+          <div class="invalid-feedback">File must be a .pdf, .txt, .csv, .jpg, .png, or .tiff</div>
+        </div>
         <%= render_remove_image_checkbox(f, :overview_image) %>
       </div>
 

--- a/lib/web/templates/phase_winner/_form.html.eex
+++ b/lib/web/templates/phase_winner/_form.html.eex
@@ -11,7 +11,8 @@
         <%= hidden_input f, :overview_image_extension %>
         <div class="mb-3">
           <input class="form-control-file" id="phase_winner_overview_image" name="phase_winner[overview_image]" type="file">
-          <div class="invalid-feedback">File must be a .pdf, .txt, .csv, .jpg, .png, or .tiff</div>
+          <div class="invalid-feedback">File must be a .jpg, .jpeg, .png, .gif </div>
+          <small class="form-text text-muted font-italic">Allowed file types: .jpg, .jpeg, .png, .gif</small>
         </div>
         <%= render_remove_image_checkbox(f, :overview_image) %>
       </div>

--- a/lib/web/templates/phase_winner/edit.html.eex
+++ b/lib/web/templates/phase_winner/edit.html.eex
@@ -20,7 +20,8 @@
       changeset: @changeset, 
       action: @action,
       challenge: @challenge,
-      phase: @phase
+      phase: @phase,
+      upload_error: @upload_error
     %>
   </div>
 </div>

--- a/lib/web/templates/phase_winner/winners/_form.html.eex
+++ b/lib/web/templates/phase_winner/winners/_form.html.eex
@@ -1,5 +1,8 @@
 <div id="winners-form">
   <div class="js-dynamic-nested-items">
+    <%= if @upload_error do %>
+      <div class="mb-3 invalid-feedback d-block">Files must be .pdf, .txt, .csv, .jpg, .png, or .tiff</div>
+    <% end %>
     <%= inputs_for(@form, :winners, [skip_hidden: true], fn winner -> %>
       <div class="js-dynamic-nested-item grid-row mb-2" data-index=<%= winner.index %>>
         <div class="form-group">

--- a/lib/web/templates/phase_winner/winners/_form.html.eex
+++ b/lib/web/templates/phase_winner/winners/_form.html.eex
@@ -32,6 +32,7 @@
           <div class="form-group">
             <div><%= label winner, :image, "Upload image (optional)", class: "control-label" %></div>
             <%= file_input winner, :image, data: [field: :image] %>
+            <small class="form-text text-muted font-italic">Allowed file types: .jpg, .jpeg, .png, .gif</small>
           </div>
 
           <div class="form-group">
@@ -73,6 +74,7 @@
         <div class="js-dynamic-nested-group form-group">
           <div><label class="control-label">Upload image (optional)</label></div>
           <%= file_input :template, :field, data: [field: :image] %>
+          <small class="form-text text-muted font-italic">Allowed file types: .jpg, .jpeg, .png, .gif</small>
         </div>
 
         <div class="js-dynamic-nested-group form-group">

--- a/lib/web/templates/submission/_form.html.eex
+++ b/lib/web/templates/submission/_form.html.eex
@@ -36,6 +36,7 @@
           <span data-user="<%= @user.email %>", id="current_user"></span>
           <div id="submission_document_upload" class="btn btn-primary">Upload file</div>
           <div class="challenge_document_upload_error invalid-feedback">File must be a .pdf, .txt, .csv, .jpg, .png, or .tiff</div>
+          <small class="form-text text-muted font-italic">Allowed file types: .pdf, .txt, .csv, .jpg, .png, or .tiff</small>
         </div>
         <span id="submission_document_upload__error-no-email" class="js-error-tag text-danger"></span>
       </div>

--- a/lib/web/templates/submission/_form.html.eex
+++ b/lib/web/templates/submission/_form.html.eex
@@ -35,6 +35,7 @@
           <%= file_input f, :document, name: "submission[document][file]", class: "my-3" %>
           <span data-user="<%= @user.email %>", id="current_user"></span>
           <div id="submission_document_upload" class="btn btn-primary">Upload file</div>
+          <div class="challenge_document_upload_error invalid-feedback">File must be a .pdf, .txt, .csv, .jpg, .png, or .tiff</div>
         </div>
         <span id="submission_document_upload__error-no-email" class="js-error-tag text-danger"></span>
       </div>


### PR DESCRIPTION
- [x] Uploading a PDF, txt, csv, jpg, png, tiff file results in success
- [x] Uploading any other file type results in an error message indicating the supported file types
- [x] The help text next to the file upload section indicates the supported types