### PR TITLE
Chal717/remove delete data pop up alert on phases section

### DIFF
--- a/assets/js/app/_radio_button_show.js
+++ b/assets/js/app/_radio_button_show.js
@@ -35,11 +35,11 @@ $(".multi-phase-toggle input[type=radio]").on("click", function() {
     $(".single-phase-section").collapse("hide")
   $(".single-phase-section").find("input").prop("disabled", true)
   } else {
-    if (window.confirm(phaseDeletionWarning)) {
-      $(".phase-fields").collapse("hide")
-      $(".phase-fields .nested-items").find("input").prop("disabled", true)
-      $(".single-phase-section").collapse("show")
-      $(".single-phase-section").find("input").prop("disabled", false)
+    if (!$("#challenge_phases_0_start_date").val()) {
+      showSinglePhaseFields()
+      return true
+    } else if (!!$("#challenge_phases_0_start_date").val() && window.confirm(phaseDeletionWarning)) {
+      showSinglePhaseFields()
       return true
     } else {
       return false
@@ -76,6 +76,13 @@ $(".js-prize-detail-toggle input[type=radio]").on("click", function() {
       break;
   }
 })
+
+function showSinglePhaseFields() {
+  $(".phase-fields").collapse("hide")
+  $(".phase-fields .nested-items").find("input").prop("disabled", true)
+  $(".single-phase-section").collapse("show")
+  $(".single-phase-section").find("input").prop("disabled", false)
+}
 
 function showMonetaryPrize() {
   prizeTotalSection.collapse("show")


### PR DESCRIPTION
Prevent 'delete phase' alert from showing on initial selection of single phase challenge

Using the start date value to determine if alert should be shown
* might be more correct to check the DB start_date value to see if it was saved and not just filled out, but concerned about over querying

- [ ] README is up to date
- [ ] Docs are up to date with changes (modules and functions)
- [ ] Tests are included for changes
- [ ] Links in emails use the `_url` route helpers
- [ ] Controllers modified contain appropriate authorization plugs
