### PR TITLE
Challenge Finder Fix

### DIFF
--- a/lib/challenge_gov/challenges.ex
+++ b/lib/challenge_gov/challenges.ex
@@ -437,12 +437,12 @@ defmodule ChallengeGov.Challenges do
 
       true ->
         Challenge
-        |> where([c], c.id == ^id)
+        |> where([c], c.id == ^id_or_slug)
         |> get_query()
 
       :error ->
         Challenge
-        |> where([c], c.custom_url == ^id)
+        |> where([c], c.custom_url == ^id_or_slug)
         |> get_query()
     end
     |> case do


### PR DESCRIPTION
Ensure there is only a number when parsing a string ID, otherwise treat as a custom url
