### PR TITLE
Update/datetime local rendering

### DIFF
--- a/assets/js/app/_date_conversion.js
+++ b/assets/js/app/_date_conversion.js
@@ -11,7 +11,7 @@ $(".js-local-date").each(function() {
 $(".js-local-datetime").each(function() {
   let timeZone = moment.tz.guess(true)
   let utc_time = $(this).text()
-  let local_time = moment(utc_time, "MM/DD/YY hh:mm A z").tz(timeZone).format("MM/DD/YY hh:mm A z")
+  let local_time = moment(utc_time).tz(timeZone).format("MM/DD/YY hh:mm A z")
 
   if (local_time != "Invalid date") { $(this).text(local_time) }
 })

--- a/lib/web/templates/site_content/show.html.eex
+++ b/lib/web/templates/site_content/show.html.eex
@@ -45,7 +45,7 @@
               </dd>
             <% end %>
 
-            <%= if @content.end_date do %>
+            <%= if @content.section === "site_wide_banner" and @content.end_date do %>
               <dt>
                 <span class="text-bold">End date: </span>
               </dt>

--- a/lib/web/views/challenge_view.ex
+++ b/lib/web/views/challenge_view.ex
@@ -93,9 +93,7 @@ defmodule Web.ChallengeView do
        when not is_nil(auto_publish_date) do
     [
       " (Publishes ",
-      content_tag(:span, "#{SharedView.readable_datetime(auto_publish_date)}",
-        class: "js-local-datetime"
-      ),
+      content_tag(:span, auto_publish_date, class: "js-local-datetime"),
       ")"
     ]
   end


### PR DESCRIPTION
Remove bugged update for js-local-datetime display. Update data rendered for auto-publish date in Status. Remove end date from challenge wizard info display


- [ ] README is up to date
- [ ] Docs are up to date with changes (modules and functions)
- [ ] Tests are included for changes
- [ ] Links in emails use the `_url` route helpers
- [ ] Controllers modified contain appropriate authorization plugs
