### PR TITLE
Update/social share palceholders

### DIFF
--- a/assets/client/src/components/ChallengeDetails.js
+++ b/assets/client/src/components/ChallengeDetails.js
@@ -257,7 +257,7 @@ export const ChallengeDetails = ({challenge, challengePhases, preview, print, ta
                 <i className="fas fa-share-alt mr-2"></i>
                 share
               </span>
-              <SocialSharingTooltip shareTooltipOpen={shareTooltipOpen} toggleShareTooltip={toggleShareTooltip} />
+              <SocialSharingTooltip shareTooltipOpen={shareTooltipOpen} toggleShareTooltip={toggleShareTooltip} challenge={challenge}/>
             </div>
           </div>
         </>

--- a/assets/client/src/components/SocialSharingTooltip.js
+++ b/assets/client/src/components/SocialSharingTooltip.js
@@ -1,31 +1,32 @@
 import React from 'react'
 import { Tooltip } from 'reactstrap'
+import { stripHtml } from "string-strip-html";
 import {FacebookShareButton, LinkedinShareButton, TwitterShareButton, EmailShareButton} from "react-share";
 
-export const SocialSharingTooltip = ({shareTooltipOpen, toggleShareTooltip}) => {
+export const SocialSharingTooltip = ({shareTooltipOpen, toggleShareTooltip, challenge}) => {
   const challengeURL = window.location.href
 
   return (
     <Tooltip placement="bottom" trigger="click" isOpen={shareTooltipOpen} target="shareChallengeButton" toggle={toggleShareTooltip} autohide={false} className="share-tooltip" innerClassName="share-tooltip__inner" arrowClassName="share-tooltip__arrow">
-      <FacebookShareButton url={challengeURL} quote="Check out this awesome challenge" hashtag="#prizechallenge">
+      <FacebookShareButton url={challengeURL} quote="Check out this challenge" hashtag="#prizechallenge">
         <svg viewBox="0 0 64 64" width="32" height="32">
           <circle cx="32" cy="32" r="31" fill="#3b5998"></circle>
           <path d="M34.1,47V33.3h4.6l0.7-5.3h-5.3v-3.4c0-1.5,0.4-2.6,2.6-2.6l2.8,0v-4.8c-0.5-0.1-2.2-0.2-4.1-0.2 c-4.1,0-6.9,2.5-6.9,7V28H24v5.3h4.6V47H34.1z" fill="white"></path>
         </svg>
       </FacebookShareButton>
-      <LinkedinShareButton url={challengeURL} title="Title of the shared page" summary="Description of the shared page" source="Source of the content (e.g. your website or application name)">
+      <LinkedinShareButton url={challengeURL} title={challenge.title} summary={stripHtml(challenge.brief_description).result} source="Challenge.Gov">
         <svg viewBox="0 0 64 64" width="32" height="32">
           <circle cx="32" cy="32" r="31" fill="#007fb1"></circle>
           <path d="M20.4,44h5.4V26.6h-5.4V44z M23.1,18c-1.7,0-3.1,1.4-3.1,3.1c0,1.7,1.4,3.1,3.1,3.1 c1.7,0,3.1-1.4,3.1-3.1C26.2,19.4,24.8,18,23.1,18z M39.5,26.2c-2.6,0-4.4,1.4-5.1,2.8h-0.1v-2.4h-5.2V44h5.4v-8.6 c0-2.3,0.4-4.5,3.2-4.5c2.8,0,2.8,2.6,2.8,4.6V44H46v-9.5C46,29.8,45,26.2,39.5,26.2z" fill="white"></path>
         </svg>
       </LinkedinShareButton>
-      <TwitterShareButton url={challengeURL} title="Title of the shared page" via="ChallengeGov" hashtags={["prizechallenge", "innovation"]} related={["Accounts to recommend following", "?"]}>
+      <TwitterShareButton url={challengeURL} title={challenge.title} via="ChallengeGov" hashtags={["prizechallenge", "innovation"]} related={[]}>
         <svg viewBox="0 0 64 64" width="32" height="32">
           <circle cx="32" cy="32" r="31" fill="#00aced"></circle>
           <path d="M48,22.1c-1.2,0.5-2.4,0.9-3.8,1c1.4-0.8,2.4-2.1,2.9-3.6c-1.3,0.8-2.7,1.3-4.2,1.6 C41.7,19.8,40,19,38.2,19c-3.6,0-6.6,2.9-6.6,6.6c0,0.5,0.1,1,0.2,1.5c-5.5-0.3-10.3-2.9-13.5-6.9c-0.6,1-0.9,2.1-0.9,3.3 c0,2.3,1.2,4.3,2.9,5.5c-1.1,0-2.1-0.3-3-0.8c0,0,0,0.1,0,0.1c0,3.2,2.3,5.8,5.3,6.4c-0.6,0.1-1.1,0.2-1.7,0.2c-0.4,0-0.8,0-1.2-0.1 c0.8,2.6,3.3,4.5,6.1,4.6c-2.2,1.8-5.1,2.8-8.2,2.8c-0.5,0-1.1,0-1.6-0.1c2.9,1.9,6.4,2.9,10.1,2.9c12.1,0,18.7-10,18.7-18.7 c0-0.3,0-0.6,0-0.8C46,24.5,47.1,23.4,48,22.1z" fill="white"></path>
         </svg>
       </TwitterShareButton>
-      <EmailShareButton url={challengeURL} subject="Subject of this email?" body="Can put a body message here" separator=" ">
+      <EmailShareButton url={challengeURL} subject="Sharing a challenge from Challenge.Gov!" body="" separator=" ">
         <svg viewBox="0 0 64 64" width="32" height="32">
           <circle cx="32" cy="32" r="31" fill="#7f7f7f"></circle>
           <path d="M17,22v20h30V22H17z M41.1,25L32,32.1L22.9,25H41.1z M20,39V26.6l12,9.3l12-9.3V39H20z" fill="white"></path>

--- a/assets/client/src/components/SocialSharingTooltip.js
+++ b/assets/client/src/components/SocialSharingTooltip.js
@@ -8,25 +8,25 @@ export const SocialSharingTooltip = ({shareTooltipOpen, toggleShareTooltip, chal
 
   return (
     <Tooltip placement="bottom" trigger="click" isOpen={shareTooltipOpen} target="shareChallengeButton" toggle={toggleShareTooltip} autohide={false} className="share-tooltip" innerClassName="share-tooltip__inner" arrowClassName="share-tooltip__arrow">
-      <FacebookShareButton url={challengeURL} quote="Check out this challenge" hashtag="#prizechallenge">
+      <FacebookShareButton url={challenge.short_url ?? challengeURL} quote="Check out this challenge" hashtag="#prizechallenge">
         <svg viewBox="0 0 64 64" width="32" height="32">
           <circle cx="32" cy="32" r="31" fill="#3b5998"></circle>
           <path d="M34.1,47V33.3h4.6l0.7-5.3h-5.3v-3.4c0-1.5,0.4-2.6,2.6-2.6l2.8,0v-4.8c-0.5-0.1-2.2-0.2-4.1-0.2 c-4.1,0-6.9,2.5-6.9,7V28H24v5.3h4.6V47H34.1z" fill="white"></path>
         </svg>
       </FacebookShareButton>
-      <LinkedinShareButton url={challengeURL} title={challenge.title} summary={stripHtml(challenge.brief_description).result} source="Challenge.Gov">
+      <LinkedinShareButton url={challenge.short_url ?? challengeURL} title={challenge.title} summary={stripHtml(challenge.brief_description).result} source="Challenge.Gov">
         <svg viewBox="0 0 64 64" width="32" height="32">
           <circle cx="32" cy="32" r="31" fill="#007fb1"></circle>
           <path d="M20.4,44h5.4V26.6h-5.4V44z M23.1,18c-1.7,0-3.1,1.4-3.1,3.1c0,1.7,1.4,3.1,3.1,3.1 c1.7,0,3.1-1.4,3.1-3.1C26.2,19.4,24.8,18,23.1,18z M39.5,26.2c-2.6,0-4.4,1.4-5.1,2.8h-0.1v-2.4h-5.2V44h5.4v-8.6 c0-2.3,0.4-4.5,3.2-4.5c2.8,0,2.8,2.6,2.8,4.6V44H46v-9.5C46,29.8,45,26.2,39.5,26.2z" fill="white"></path>
         </svg>
       </LinkedinShareButton>
-      <TwitterShareButton url={challengeURL} title={challenge.title} via="ChallengeGov" hashtags={["prizechallenge", "innovation"]} related={[]}>
+      <TwitterShareButton url={challenge.short_url ?? challengeURL} title={challenge.title} via="ChallengeGov" hashtags={["prizechallenge", "innovation"]} related={[]}>
         <svg viewBox="0 0 64 64" width="32" height="32">
           <circle cx="32" cy="32" r="31" fill="#00aced"></circle>
           <path d="M48,22.1c-1.2,0.5-2.4,0.9-3.8,1c1.4-0.8,2.4-2.1,2.9-3.6c-1.3,0.8-2.7,1.3-4.2,1.6 C41.7,19.8,40,19,38.2,19c-3.6,0-6.6,2.9-6.6,6.6c0,0.5,0.1,1,0.2,1.5c-5.5-0.3-10.3-2.9-13.5-6.9c-0.6,1-0.9,2.1-0.9,3.3 c0,2.3,1.2,4.3,2.9,5.5c-1.1,0-2.1-0.3-3-0.8c0,0,0,0.1,0,0.1c0,3.2,2.3,5.8,5.3,6.4c-0.6,0.1-1.1,0.2-1.7,0.2c-0.4,0-0.8,0-1.2-0.1 c0.8,2.6,3.3,4.5,6.1,4.6c-2.2,1.8-5.1,2.8-8.2,2.8c-0.5,0-1.1,0-1.6-0.1c2.9,1.9,6.4,2.9,10.1,2.9c12.1,0,18.7-10,18.7-18.7 c0-0.3,0-0.6,0-0.8C46,24.5,47.1,23.4,48,22.1z" fill="white"></path>
         </svg>
       </TwitterShareButton>
-      <EmailShareButton url={challengeURL} subject="Sharing a challenge from Challenge.Gov!" body="" separator=" ">
+      <EmailShareButton url={challenge.short_url ?? challengeURL} subject="Sharing a challenge from Challenge.Gov!" body="" separator=" ">
         <svg viewBox="0 0 64 64" width="32" height="32">
           <circle cx="32" cy="32" r="31" fill="#7f7f7f"></circle>
           <path d="M17,22v20h30V22H17z M41.1,25L32,32.1L22.9,25H41.1z M20,39V26.6l12,9.3l12-9.3V39H20z" fill="white"></path>

--- a/assets/css/app/_base.scss
+++ b/assets/css/app/_base.scss
@@ -572,8 +572,17 @@ form {
 
   /* (submission show) */
 
-  .editor-text-reset {
+  .editor-text-submissions {
     padding: 0 7.5px;
+
+    p {
+      padding: 0;
+      margin: 0;
+    }
+  }
+
+  .editor-text-reset {
+    padding: 0;
 
     p {
       padding: 0;

--- a/lib/challenge_gov/challenges/challenge.ex
+++ b/lib/challenge_gov/challenges/challenge.ex
@@ -116,6 +116,7 @@ defmodule ChallengeGov.Challenges.Challenge do
     field(:announcement_datetime, :utc_datetime)
     field(:gov_delivery_topic, :string)
     field(:gov_delivery_subscribers, :integer, default: 0)
+    field(:short_url, :string)
 
     field(:upload_logo, :boolean)
     field(:is_multi_phase, :boolean)
@@ -324,7 +325,8 @@ defmodule ChallengeGov.Challenges.Challenge do
       :prize_type,
       :how_to_enter_link,
       :announcement,
-      :announcement_datetime
+      :announcement_datetime,
+      :short_url
     ])
     |> cast_assoc(:non_federal_partners, with: &NonFederalPartner.draft_changeset/2)
     |> cast_assoc(:events)

--- a/lib/web/templates/challenge/review/_details.html.eex
+++ b/lib/web/templates/challenge/review/_details.html.eex
@@ -25,6 +25,13 @@
   <div><%= ChallengeView.public_details_url(@challenge) %></div>
 </div>
 <br/>
+<%= if Accounts.has_admin_access?(@user) and @challenge.short_url do %>
+  <div>
+    <div class="text-bold">Short url:</div>
+    <div><%= @challenge.short_url %></div>
+  </div>
+  <br/>
+<% end %>
 <div>
   <div class="text-bold">External url:</div>
   <div><%= @challenge.external_url %></div>

--- a/lib/web/templates/challenge/review/_details.html.eex
+++ b/lib/web/templates/challenge/review/_details.html.eex
@@ -32,12 +32,12 @@
 <br/>
 <div>
   <div class="text-bold">Brief description:</div>
-  <div><%= SharedView.render_safe_html(@challenge.brief_description) %></div>
+  <div class="editor-text-reset"><%= SharedView.render_safe_html(@challenge.brief_description) %></div>
 </div>
 <br/>
 <div>
   <div class="text-bold">Description:</div>
-  <div><%= SharedView.render_safe_html(@challenge.description) %></div>
+  <div class="editor-text-reset"><%= SharedView.render_safe_html(@challenge.description) %></div>
 </div>
 <br/>
 <div>

--- a/lib/web/templates/challenge/review/_prizes.html.eex
+++ b/lib/web/templates/challenge/review/_prizes.html.eex
@@ -22,5 +22,5 @@
 <br/>
 <div>
   <div class="text-bold">Prize description:</div>
-  <div><%= SharedView.render_safe_html(@challenge.prize_description) %></div>
+  <div class="editor-text-reset"><%= SharedView.render_safe_html(@challenge.prize_description) %></div>
 </div>

--- a/lib/web/templates/challenge/review/_resources.html.eex
+++ b/lib/web/templates/challenge/review/_resources.html.eex
@@ -26,5 +26,5 @@
 <br/>
 <div>
   <div class="text-bold">Frequently asked questions:</div>
-  <div><%= SharedView.render_safe_html(@challenge.faq) %></div>
+  <div class="editor-text-reset"><%= SharedView.render_safe_html(@challenge.faq) %></div>
 </div>

--- a/lib/web/templates/challenge/review/_rules.html.eex
+++ b/lib/web/templates/challenge/review/_rules.html.eex
@@ -7,7 +7,7 @@
 <br/>
 <div>
   <div class="text-bold">Eligibility requirements:</div>
-  <div><%= SharedView.render_safe_html(@challenge.eligibility_requirements) %></div>
+  <div class="editor-text-reset"><%= SharedView.render_safe_html(@challenge.eligibility_requirements) %></div>
 </div>
 <br/>
 <div>
@@ -17,12 +17,12 @@
 <br/>
 <div>
   <div class="text-bold">Rules:</div>
-  <div><%= SharedView.render_safe_html(@challenge.rules) %></div>
+  <div class="editor-text-reset"><%= SharedView.render_safe_html(@challenge.rules) %></div>
 </div>
 <br/>
 <div>
   <div class="text-bold">Terms and conditions:</div>
-  <div><%= SharedView.render_safe_html(@challenge.terms_and_conditions) %></div>
+  <div class="editor-text-reset"><%= SharedView.render_safe_html(@challenge.terms_and_conditions) %></div>
 </div>
 <br/>
 <div>

--- a/lib/web/templates/challenge/wizard/_details.html.eex
+++ b/lib/web/templates/challenge/wizard/_details.html.eex
@@ -3,14 +3,18 @@
 <h4>Add challenge details</h4>
 <br/>
 <p class="form__note"><span class="form__note--red">*</span>Required field</p>
-<br/>
 
 <%= FormView.text_field(@form, :title, label: "Challenge title (90 character limit)", limit: 90, required: true) %>
 <p class="ml-2 text-muted">Provide the official title of your challenge. Your challenge title will appear in your challenge’s listing tile on the Challenge.gov homepage.</p>
+
+<br/>
+
 <%= FormView.text_field(@form, :tagline, label: "Tagline (400 character limit)", limit: 400, required: true) %>
 <p class="ml-2 text-muted">Provide a clear one-sentence call to action for solvers - essentially your challenge’s headline. It is required that taglines be limited to 90 characters or less. The tagline will also appear at the top of your individual challenge page, and on the challenge preview tile.</p>
 
+<br/>
 <hr/>
+<br/>
 
 <%= FormView.select_field(@form, :primary_type, collection: Challenges.challenge_types(), class: "js-challenge-type", label: "Primary challenge type (select from list)", prompt: "", required: true) %>
 <p class="ml-2 text-muted">Select a category that best describes your challenge.</p>
@@ -24,6 +28,9 @@
     <%= error_tag(@form, :types) %>
   </div>
 </div>
+
+<br/>
+
 <div class="<%= FormView.form_group_classes(@form, :types) %>">
   <label for="challenge_types" class="col">Additional challenge type <em>(optional)</em></label>
   <div class="col">
@@ -34,6 +41,9 @@
     <%= error_tag(@form, :types) %>
   </div>
 </div>
+
+<br/>
+
 <div class="<%= FormView.form_group_classes(@form, :types) %>">
   <label for="challenge_types" class="col">Additional challenge type <em>(optional)</em></label>
   <div class="col">
@@ -44,10 +54,15 @@
     <%= error_tag(@form, :types) %>
   </div>
 </div>
+
+<br/>
+
 <%= FormView.text_field(@form, :other_type, label: "Other challenge type (optional) (45 character limit)", limit: 45) %>
 <p class="ml-2 text-muted">Free type a category that best describe your challenge</p>
 
+<br/>
 <hr/>
+<br/>
 
 <div class="form-group">
   <%= label @form, :custom_url, "Custom url (optional)", class: "col-md-4" %>
@@ -60,7 +75,10 @@
 
 <%= FormView.text_field(@form, :external_url, label: "Existing external challenge link (optional)") %>
 <p class="ml-2 text-muted">If the challenge is hosted outside of the Challenge.gov platform, enter the link for users to visit that website.</p>
+
+<br/>
 <hr/>
+<br/>
 
 <div class="col">
   <label for="brief_description">Short description (200 character limit)</label>
@@ -68,13 +86,17 @@
   <p class="ml-2 text-muted">Provide a general overview of your challenge, including any background on the problem you’re trying to solve.</p>
 </div>
 
+<br/>
+
 <div class="col">
   <label><%= "Long description (15000 character limit)" %> <span class="required">*</span></label>
   <%= FormView.rt_textarea_field(@form, :description, limit: 15000) %>
   <p class="ml-2 text-muted">Provide a detailed overview of your challenge, including any background on the problem you’re trying to solve, and any key dates you want to highlight.</p>
 </div>
 
+<br/>
 <hr/>
+<br/>
 
 <div class="challenge-file-upload col" data-section=<%= @section %>>
   <label class="control-label">Upload additional description materials (optional)</label>
@@ -102,7 +124,9 @@
   </div>
 </div>
 
+<br/>
 <hr/>
+<br/>
 
 <div class="col">
   <label class="control-label"><%= FormView.label_field @form, :upload_logo, label: "Upload challenge logo", required: true %></label>
@@ -142,6 +166,7 @@
   </div>
 </div>
 
+<br/>
 <hr/>
 <br/>
 

--- a/lib/web/templates/challenge/wizard/_details.html.eex
+++ b/lib/web/templates/challenge/wizard/_details.html.eex
@@ -73,6 +73,17 @@
   <%= FormView.text_field(@form, :custom_url, label: nil, placeholder: "my-custom-challenge-name") %>
 </div>
 
+<br/>
+
+<%= if Accounts.has_admin_access?(@user) do %>
+  <div class="form-group">
+    <%= FormView.text_field(@form, :short_url, label: "Short url (optional)", placeholder: "https://go.usa.gov/lmnop") %>
+    <p class="text-muted">The short url will be used for social media and posting purposes.</p>
+  </div>
+  <br/>
+<% end %>
+
+
 <%= FormView.text_field(@form, :external_url, label: "Existing external challenge link (optional)") %>
 <p class="ml-2 text-muted">If the challenge is hosted outside of the Challenge.gov platform, enter the link for users to visit that website.</p>
 

--- a/lib/web/templates/challenge/wizard/_general.html.eex
+++ b/lib/web/templates/challenge/wizard/_general.html.eex
@@ -2,36 +2,63 @@
 <%= hidden_input @form, :non_federal_partners, value: [] %>
 
 <h3>Add general information</h3>
+
 <br/>
+
 <p class="form__note"><span class="form__note--red">*</span>Required field</p>
 <%= wizard_challenge_managers_field(@form, @user, @changeset) %>
 <p class="ml-2 text-muted">Provide the name of the challenge manager.</p>
 <%= if !Accounts.has_admin_access?(@user) do %>
   <p class="ml-2 text-muted">Contact GSA admin at <a href="mailto:team@challenge.gov" target="_blank">team@challenge.gov</a> to add additional challenge managers.</p>
 <% end %>
+
+<br/>
+
 <%= FormView.text_field(@form, :challenge_manager, label: "Challenge manager of record (does not appear on public listing)", required: true) %>
 <p class="ml-2 text-muted">Provide the name of the challenge manager.  For Challenge.Gov team use only. This does not display on the public site.</p>
+
+<br/>
+
 <%= FormView.email_field(@form, :challenge_manager_email, label: "Challenge manager email (does not appear on public listing)", placeholder: "challenge_manager@example.com", required: true) %>
 <p class="ml-2 text-muted">Provide an email address where the challenge manager can be contacted. For Challenge.Gov team use only. This does not display on the public site.</p>
+
+<br/>
+
 <%= FormView.email_field(@form, :poc_email, label: "Point of contact email", placeholder: "point_of_contact@example.com", required: true) %>
 <p class="ml-2 text-muted">Provide an email address for participants and members of the public to use for questions about your challenge. This will not appear publicly, instead it will be the receiving email to the form on the contact page of the challenge.</p>
+
+<br/>
 <hr/>
+<br/>
+
 <%= FormView.select_field(@form, :agency_id, collection: Enum.map(Agencies.all_for_select(), &{&1.name, &1.id}), label: "Lead agency name (select from list)", prompt: "Choose an agency", required: true) %>
 <p class="ml-2 text-muted">Select the name of the lead agency sponsoring the challenge.</p>
 <%= FormView.select_field(@form, :sub_agency_id, collection: Enum.map(Web.AgencyView.sub_agencies(@form.data.agency), &{&1.name, &1.id}), label: "Sub-agency name (optional) select from list", prompt: "Choose a sub-agency") %>
 <p class="ml-2 text-muted">Select the name of the sub-agency sponsoring the challenge.</p>
+
+<br/>
 <hr/>
+<br/>
+
 <div class="form-group">
   <label class="col-md-4">Federal partners (optional) select from list</label>
   <p class="ml-2 text-muted">Select the name of any additional agencies sponsoring the challenge.</p>
   <%= render Web.ChallengeView, "dynamic_fields/_federal_partners.html", form: @form %>
 </div>
+
+<br/>
 <hr/>
+<br/>
+
 <div class="form-group">
   <label class="col-md-4">Non federal partners (optional)</label>
   <p class="ml-2 text-muted">Fill in any non-federal partners you have for the challenge.</p>
   <%= FormView.dynamic_nested_fields(@form, :non_federal_partners, [:name]) %>
 </div>
+
+<br/>
 <hr/>
+<br/>
+
 <%= FormView.text_field(@form, :fiscal_year, label: "Fiscal year ", placeholder: "FY22", required: true) %>
 <p class="ml-2 text-muted">Provide the fiscal year(s) during which your challenge is being run (launched, ongoing, completed). This must be in the format FY[YY]-FY[YY]</p>

--- a/lib/web/templates/challenge/wizard/_prizes.html.eex
+++ b/lib/web/templates/challenge/wizard/_prizes.html.eex
@@ -24,9 +24,14 @@
   <%= FormView.currency_field(@form, :prize_total, label: "Total cash prizes offered", required: true) %>
 </div>
 <p class="ml-2 text-muted">Provide the total cash prize pool.</p>
+
+<br/>
+
 <div class="js-non-monetary-prize collapse">
   <%= FormView.text_field(@form, :non_monetary_prizes, label: "Non-monetary prize award", required: true) %>
 </div>
+
+<br/>
 
 <div class="col">
   <label for="challenge_prize_description">Prize description / breakdown (optional)</label>

--- a/lib/web/templates/challenge/wizard/_resources.html.eex
+++ b/lib/web/templates/challenge/wizard/_resources.html.eex
@@ -8,7 +8,9 @@
   <%= FormView.rt_textarea_field(@form, :faq, limit: 15000) %>
 </div>
 <p class="ml-2 mb-4 text-muted">Provide a general summary of any information you want your solvers to know about the challenge.</p>
+
 <hr/>
+<br/>
 
 <div class="col">
   <label class="control-label">Upload image (optional)</label>
@@ -28,6 +30,7 @@
 </div>
 
 <hr/>
+<br/>
 
 <div class="challenge-file-upload col" data-section=<%= @section %>>
   <label class="control-label">Upload supporting documents (optional)</label>
@@ -40,7 +43,7 @@
     <div class="challenge_document_upload btn btn-primary">Upload file</div>
     <div class="challenge_document_upload_error invalid-feedback">File must be a .pdf, .txt, .csv, .jpg, .png, or .tiff</div>
     <small class="form-text text-muted font-italic">Allowed file types: .pdf, .txt, .csv, .jpg, .png, or .tiff</small>
-  </div>              
+  </div>
 
   <br/>
 
@@ -58,6 +61,7 @@
 </div>
 
 <hr/>
+<br/>
 
 <div class="challenge-file-upload col" data-section="faq">
   <label class="control-label">Upload FAQ documents (optional)</label>

--- a/lib/web/templates/challenge/wizard/_rules.html.eex
+++ b/lib/web/templates/challenge/wizard/_rules.html.eex
@@ -9,19 +9,27 @@
 </div>
 <p class="ml-2 text-muted">Provide the eligibility requirements for your challenge.</p>
 
+<br/>
+
 <div class="col">
   <label><%= "Rules" %> <span class="required">*</span></label>
   <%= FormView.rt_textarea_field(@form, :rules) %>
 </div>
 <p class="ml-2 text-muted">Provide the rules for your challenge. If your rules are lengthy, consider providing a more digestible summary and then a link to an official document or web page with the complete rules.</p>
 
+<br/>
+
 <%= FormView.checkbox_field(@form, :terms_equal_rules, label: "Terms and conditions same as rules", class: "js-terms-equal-rules", required: true) %>
 <p class="ml-2 text-muted">Select if the terms & conditions are the same as rules or provide the terms & conditions for your challenge.</p>
+
+<br/>
 
 <div class="col">
   <label><%= "Terms and conditions" %> <span class="required">*</span></label>
   <%= FormView.rt_textarea_field(@form, :terms_and_conditions) %>
 </div>
+
+<br/>
 
 <%= FormView.select_field(@form, :legal_authority, collection: Challenges.legal_authority(), label: "Legal authority (select from list)", prompt: "Choose a legal authority", required: true) %>
 <%= FormView.text_field(@form, :legal_authority, label: "Enter other legal authority name") %>

--- a/lib/web/templates/challenge/wizard/_timeline.html.eex
+++ b/lib/web/templates/challenge/wizard/_timeline.html.eex
@@ -42,9 +42,11 @@
         <div class="row">
           <div class="remove-nested-section btn btn-link text-danger">Remove event</div>
         </div>
+        
         <hr/>
+
       </div>
-    <% end) %>      
+    <% end) %>
   </div>
 
   <!-- Add new timeline event button -->

--- a/lib/web/templates/submission/show.html.eex
+++ b/lib/web/templates/submission/show.html.eex
@@ -39,11 +39,11 @@
             </div>
             <div class="form-group">
               <label class="col"><strong>Brief description:</strong></label>
-              <div class="col ql-editor editor-text-reset"><%= SharedView.render_safe_html(@submission.brief_description) %></div>
+              <div class="col ql-editor editor-text-submissions"><%= SharedView.render_safe_html(@submission.brief_description) %></div>
             </div>
             <div class="form-group">
               <label class="col"><strong>Description:</strong></label>
-              <div class="col ql-editor editor-text-reset"><%= SharedView.render_safe_html(@submission.description) %></div>
+              <div class="col ql-editor editor-text-submissions"><%= SharedView.render_safe_html(@submission.description) %></div>
             </div>
             <%= if @submission.external_url do %>
               <div class="form-group">

--- a/lib/web/views/api/challenge_view.ex
+++ b/lib/web/views/api/challenge_view.ex
@@ -157,7 +157,8 @@ defmodule Web.Api.ChallengeView do
       winner_information: challenge.winner_information,
       winner_image: ChallengeView.winner_img_url(challenge),
       gov_delivery_topic_subscribe_link: GovDelivery.public_subscribe_link(challenge),
-      subscriber_count: Challenges.subscriber_count(challenge)
+      subscriber_count: Challenges.subscriber_count(challenge),
+      short_url: challenge.short_url
     }
   end
 end

--- a/priv/repo/migrations/20211019185650_add_short_urls_to_challenges.exs
+++ b/priv/repo/migrations/20211019185650_add_short_urls_to_challenges.exs
@@ -1,0 +1,9 @@
+defmodule ChallengeGov.Repo.Migrations.AddShortUrlsToChallenges do
+  use Ecto.Migration
+
+  def change do
+    alter table(:challenges) do
+      add(:short_url, :string)
+    end
+  end
+end

--- a/test/web/controllers/api/challenge_controller_test.exs
+++ b/test/web/controllers/api/challenge_controller_test.exs
@@ -379,7 +379,8 @@ defmodule Web.Api.ChallengeControllerTest do
       "gov_delivery_topic_subscribe_link" => nil,
       "subscriber_count" => 0,
       "is_archived" => Challenges.is_archived_new?(challenge),
-      "is_closed" => Challenges.is_closed?(challenge)
+      "is_closed" => Challenges.is_closed?(challenge),
+      "short_url" => nil
     }
   end
 end


### PR DESCRIPTION
Add challenge specific info to social sharing and short_url field to challenges that can be used for posts

- [ ] README is up to date
- [ ] Docs are up to date with changes (modules and functions)
- [ ] Tests are included for changes
- [ ] Links in emails use the `_url` route helpers
- [ ] Controllers modified contain appropriate authorization plugs
