### PR TITLE
Chal 760/agency UI refactor

### DIFF
--- a/assets/css/app/_dashboard.scss
+++ b/assets/css/app/_dashboard.scss
@@ -35,4 +35,11 @@
 .dap_report_loading {
   height: 2em;
   width: 5em;
+  
+// Agencies
+
+.clear-after::after {
+  display: inherit;
+  clear: inherit;
+  content: inherit;
 }

--- a/assets/css/app/_dashboard.scss
+++ b/assets/css/app/_dashboard.scss
@@ -35,6 +35,7 @@
 .dap_report_loading {
   height: 2em;
   width: 5em;
+}
   
 // Agencies
 

--- a/lib/challenge_gov/agencies.ex
+++ b/lib/challenge_gov/agencies.ex
@@ -36,6 +36,20 @@ defmodule ChallengeGov.Agencies do
     |> Repo.paginate(opts[:page], opts[:per])
   end
 
+  @doc """
+  Get all parent agencies
+  """
+  def all_highest_level(opts \\ []) do
+    opts = Enum.into(opts, %{})
+
+    Agency
+    |> where([t], is_nil(t.deleted_at))
+    |> where([t], is_nil(t.parent_id))
+    |> Filter.filter(opts[:filter], __MODULE__)
+    |> preload([:parent, :sub_agencies, members: ^member_query()])
+    |> Repo.paginate(opts[:page], opts[:per])
+  end
+
   def all_for_select() do
     Agency
     |> where([a], is_nil(a.deleted_at))

--- a/lib/challenge_gov/agencies/agency.ex
+++ b/lib/challenge_gov/agencies/agency.ex
@@ -46,7 +46,7 @@ defmodule ChallengeGov.Agencies.Agency do
       :name,
       :parent_id
     ])
-    |> validate_required([:name])
+    |> validate_required([:name, :acronym])
   end
 
   def update_changeset(struct, params) do
@@ -57,7 +57,7 @@ defmodule ChallengeGov.Agencies.Agency do
       :name,
       :parent_id
     ])
-    |> validate_required([:name])
+    |> validate_required([:name, :acronym])
   end
 
   def avatar_changeset(struct, key, extension) do

--- a/lib/web/controllers/agency_controller.ex
+++ b/lib/web/controllers/agency_controller.ex
@@ -3,8 +3,7 @@ defmodule Web.AgencyController do
 
   alias ChallengeGov.Agencies
 
-  plug(Web.Plugs.EnsureRole, [:super_admin, :admin] when action in [:index, :show, :delete])
-  plug(Web.Plugs.EnsureRole, :super_admin when action not in [:index, :show, :delete])
+  plug(Web.Plugs.EnsureRole, [:super_admin, :admin])
   plug(Web.Plugs.FetchPage when action in [:index])
 
   action_fallback(Web.FallbackController)
@@ -36,9 +35,12 @@ defmodule Web.AgencyController do
     end
   end
 
-  def new(conn, _params) do
+  def new(conn, params) do
+    parent_id = Map.get(params, "id", nil)
+
     conn
     |> assign(:changeset, Agencies.new())
+    |> assign(:parent_id, parent_id)
     |> render("new.html")
   end
 

--- a/lib/web/controllers/agency_controller.ex
+++ b/lib/web/controllers/agency_controller.ex
@@ -14,11 +14,13 @@ defmodule Web.AgencyController do
     %{page: page, per: per} = conn.assigns
     filter = Map.get(params, "filter", %{})
     sort = Map.get(params, "sort", %{})
-    %{page: agencies, pagination: pagination} = Agencies.all(filter: filter, page: page, per: per)
+
+    %{page: parent_agencies, pagination: pagination} =
+      Agencies.all_highest_level(filter: filter, page: page, per: per)
 
     conn
     |> assign(:user, user)
-    |> assign(:agencies, agencies)
+    |> assign(:agencies, parent_agencies)
     |> assign(:filter, filter)
     |> assign(:sort, sort)
     |> assign(:pagination, pagination)

--- a/lib/web/router.ex
+++ b/lib/web/router.ex
@@ -169,6 +169,7 @@ defmodule Web.Router do
     get("/reports", ReportsController, :new)
 
     resources("/agencies", AgencyController)
+    get("/agencies/new/:id", AgencyController, :new)
     post("/agencies/:id/remove_logo", AgencyController, :remove_logo, as: :agency)
 
     post("/users/:id/toggle", UserController, :toggle, as: :user)

--- a/lib/web/templates/agency/_form.html.eex
+++ b/lib/web/templates/agency/_form.html.eex
@@ -1,8 +1,9 @@
 <%= form_for(@changeset, @path, [class: "form-horizontal", multipart: true], fn f -> %>
+  <%= hidden_input(f, :parent_id, value: @parent_id) %>
   <div class="card-body">
     <%= FormView.text_field(f, :name, label: "Name", required: true) %>
 
-    <%= FormView.text_field(f, :description, label: "Description", required: true) %>
+    <%= FormView.text_field(f, :acronym, label: "Acronym", required: true) %>
 
     <%= FormView.file_field(f, :avatar, label: "Logo") do %>
       <%= if @data.avatar_key do %>
@@ -10,7 +11,7 @@
         <%= AgencyView.avatar_img(@data, height: 100) %>
       <% end %>
     <% end %>
-  </div>            
+  </div>
 
   <div class="card-footer">
     <%= submit("Submit", class: "btn btn-primary pull-right") %>

--- a/lib/web/templates/agency/edit.html.eex
+++ b/lib/web/templates/agency/edit.html.eex
@@ -9,7 +9,7 @@
     <div class="row mb-2">
       <div class="col-sm-6">
         <h1 class="m-0 text-dark">
-          Edit Agency: <%= @agency.name %>
+          <%= edit_title(@agency) %> <%= @agency.name %>
         </h1>
       </div>
     </div>
@@ -20,8 +20,8 @@
   <div class="container-fluid">
     <div class="row">
       <div class="col-md-12">
-        <div class="card">        
-          <%= render Web.AgencyView, "_form.html", changeset: @changeset, data: @changeset.data, path: Routes.agency_path(@conn, :update, @agency.id) %>
+        <div class="card">
+          <%= render Web.AgencyView, "_form.html", changeset: @changeset, data: @changeset.data, parent_id: @agency.parent_id, path: Routes.agency_path(@conn, :update, @agency.id) %>
         </div>
       </div>
     </div>

--- a/lib/web/templates/agency/index.html.eex
+++ b/lib/web/templates/agency/index.html.eex
@@ -8,7 +8,7 @@
     <div class="row mb-2">
       <div class="col-sm-6">
         <h1 class="m-0 text-dark">
-          <span>Agencies</span>          
+          <span>Agencies</span>
           <%= link "New", to: Routes.agency_path(@conn, :new), class: "btn btn-primary" %>
           <a class="btn btn-info" data-widget="control-sidebar" href="#">Filter</a>
           <%= if is_map(@filter) && map_size(@filter) > 0 do %>

--- a/lib/web/templates/agency/new.html.eex
+++ b/lib/web/templates/agency/new.html.eex
@@ -6,9 +6,9 @@
       %{text: "New"}
     ])%>
     <div class="row mb-2">
-      <div class="col-sm-6">
+      <div class="col">
         <h1 class="m-0 text-dark">
-          New Agency
+          <%= new_title(@parent_id) %>
         </h1>
       </div>
     </div>
@@ -20,7 +20,7 @@
     <div class="row">
       <div class="col-md-12">
         <div class="card">
-          <%= render Web.AgencyView, "_form.html", changeset: @changeset, data: @changeset.data, path: Routes.agency_path(@conn, :create) %>
+          <%= render Web.AgencyView, "_form.html", changeset: @changeset, data: @changeset.data, parent_id: @parent_id, path: Routes.agency_path(@conn, :create) %>
         </div>
       </div>
     </div>

--- a/lib/web/templates/agency/show.html.eex
+++ b/lib/web/templates/agency/show.html.eex
@@ -2,7 +2,8 @@
   <div class="container-fluid">
     <%= SharedView.render_breadcrumbs([
       %{text: "Home", route: Routes.dashboard_path(@conn, :index)},
-      %{text: "Challenges", route: Routes.agency_path(@conn, :index)},
+      %{text: "Site Management", route: Routes.site_content_path(@conn, :index)},
+      %{text: "Agencies", route: Routes.agency_path(@conn, :index)},
       %{text: @agency.name}
     ])%>
     <div class="row mb-2">
@@ -20,8 +21,8 @@
     <div class="row">
       <div class="col-md-12">
         <div class="card">
-          <div class="card-header">
-            <h3 class="card-title">Information</h3>
+          <div class="card-header clear-after d-flex justify-content-between">
+            <h3 class="card-title font-weight-bold align-self-center">Agency Details</h3>
             <div class="card-tools">
               <%= link("Edit", to: Routes.agency_path(@conn, :edit, @agency.id), class: "btn btn-default mr-2") %>
               <%= link("Delete", to: Routes.agency_path(@conn, :delete, @agency.id), class: "btn btn-danger", method: :delete, data: [confirm: "Are you sure?"]) %>
@@ -39,8 +40,8 @@
                 <br/>
               <% end %>
 
-              <dt>Description</dd>
-              <dd><%= @agency.description %></dd>
+              <dt>Acronym</dd>
+              <dd><%= @agency.acronym %></dd>
               <br/>
 
               <dt>Logo</dd>
@@ -56,22 +57,29 @@
       </div>  
     </div>
 
-    <div class="row">
-      <div class="col-md-12">
-        <div class="card">
-          <div class="card-header">
-            <h3 class="card-title">Members</h3>
-          </div>
-          <div class="card-body">
-            <ul>            
-              <%= Enum.map(@members, fn member -> %>
-                <li><%= link(member.user.email, to: Routes.user_path(@conn, :show, member.user_id)) %></li>
+    <%= if !@agency.parent do %>
+      <div class="row">
+        <div class="col-md-12">
+          <div class="card">
+            <div class="card-header clear-after d-flex justify-content-between">
+              <h3 class="card-title align-self-center">Agency Component</h3>
+              <span><%= link("Add", to: Routes.agency_path(@conn, :new, @agency.id), class: "btn btn-info") %></span>
+            </div>
+            <div class="card-body">
+              <%= Enum.map(active_component_agencies(@agency.sub_agencies), fn sub_agency -> %>
+                <div class="d-flex justify-content-between">
+                  <%= link(sub_agency.name, to: Routes.agency_path(@conn, :show, sub_agency.id)) %>
+                  <div>
+                    <%= link("Edit", to: Routes.agency_path(@conn, :edit, sub_agency.id), class: "btn btn-default btn-xs mx-1") %>
+                    <%= link("Delete", to: Routes.agency_path(@conn, :delete, sub_agency.id), class: "btn btn-danger btn-xs mx-1", method: :delete, data: [confirm: "Are you sure?"]) %>
+                  </div>
+                </div>
               <% end) %>
-            </ul>
+            </div>
           </div>
         </div>
       </div>
-    </div>
+  <% end %>
 
     <div class="row">
       <div class="col-md-12">

--- a/lib/web/views/agency_view.ex
+++ b/lib/web/views/agency_view.ex
@@ -14,6 +14,23 @@ defmodule Web.AgencyView do
     end
   end
 
+  def edit_title(agency) do
+    if agency.parent do
+      "Edit Component:"
+    else
+      "Edit Agency:"
+    end
+  end
+
+  def new_title(parent_id) do
+    if parent_id do
+      {:ok, parent} = Agencies.get(parent_id)
+      "Add Component: #{parent.name}"
+    else
+      "New Agency"
+    end
+  end
+
   def avatar_img(agency, opts \\ []) do
     case is_nil(agency) or is_nil(agency.avatar_key) do
       true ->
@@ -36,6 +53,11 @@ defmodule Web.AgencyView do
       false ->
         Storage.url(Avatar.avatar_path(agency, "original"), signed: [expires_in: 3600])
     end
+  end
+
+  def active_component_agencies(component_agencies) do
+    component_agencies
+    |> Enum.filter(fn ca -> is_nil(ca.deleted_at) end)
   end
 
   def team_description(%{description: nil}), do: ""

--- a/test/support/test_helpers/agency_helpers.ex
+++ b/test/support/test_helpers/agency_helpers.ex
@@ -9,7 +9,7 @@ defmodule ChallengeGov.TestHelpers.AgencyHelpers do
     Map.merge(
       %{
         name: "Test Agency",
-        description: "Test desription for an agency"
+        acronym: "TA"
       },
       attributes
     )


### PR DESCRIPTION
Restructure Agency UI to reflect agency relationships and levels

- [ ] README is up to date
- [ ] Docs are up to date with changes (modules and functions)
- [ ] Tests are included for changes
- [ ] Links in emails use the `_url` route helpers
- [ ] Controllers modified contain appropriate authorization plugs
