### PR TITLE
Allow how-to-enter link to redirect submissions externally

### DIFF
--- a/assets/client/src/components/ChallengeDetails.js
+++ b/assets/client/src/components/ChallengeDetails.js
@@ -129,6 +129,8 @@ export const ChallengeDetails = ({challenge, challengePhases, preview, print, ta
     let applyButtonUrl = null
     if (challenge.external_url) {
       applyButtonUrl = challenge.external_url
+    } else if (challenge.how_to_enter_link) {
+      applyButtonUrl = challenge.how_to_enter_link
     } else if (!preview) {
       applyButtonUrl = apiUrl + `/challenges/${challenge.id}/submissions/new`
     }
@@ -139,6 +141,9 @@ export const ChallengeDetails = ({challenge, challengePhases, preview, print, ta
 
     if (challenge.external_url) {
       applyButtonText = ["View on external website", <i key={1} className="fa fa-external-link-alt ml-3"></i>]
+      applyButtonAttr.target = "_blank"
+    } else if (challenge.how_to_enter_link) {
+      applyButtonText = ["Apply on external website", <i key={1} className="fa fa-external-link-alt ml-3"></i>]
       applyButtonAttr.target = "_blank"
     } else {
       if (bridgeApplyBlocked && challenge.id <= 1288 && challenge.id != 1287) {

--- a/lib/web/templates/challenge/wizard/_how_to_enter.html.eex
+++ b/lib/web/templates/challenge/wizard/_how_to_enter.html.eex
@@ -15,3 +15,4 @@
   <%= FormView.text_field(@form, :how_to_enter_link, label: "External website how-to-enter link (optional)") %>
 </div>
 <p class="ml-2 text-muted"><b>How to Enter:</b> Provide the website URL or email address that is specific to any entry guidelines.</p>
+<p class="ml-2 text-muted">Solvers will be redirected to this url when applying if filled in</p>

--- a/lib/web/views/api/challenge_view.ex
+++ b/lib/web/views/api/challenge_view.ex
@@ -106,6 +106,7 @@ defmodule Web.Api.ChallengeView do
       fiscal_year: challenge.fiscal_year,
       faq: challenge.faq,
       how_to_enter: HtmlSanitizeEx.basic_html(challenge.how_to_enter),
+      how_to_enter_link: challenge.how_to_enter_link,
       id: challenge.id,
       is_archived: Challenges.is_archived_new?(challenge),
       is_closed: Challenges.is_closed?(challenge),

--- a/test/web/controllers/api/challenge_controller_test.exs
+++ b/test/web/controllers/api/challenge_controller_test.exs
@@ -362,6 +362,7 @@ defmodule Web.Api.ChallengeControllerTest do
       "terms_and_conditions" => "Test terms",
       "non_monetary_prizes" => nil,
       "how_to_enter" => "",
+      "how_to_enter_link" => nil,
       "events" => [],
       "start_date" => nil,
       "non_federal_partners" => [],


### PR DESCRIPTION
lib/web/views/api/challenge_view.ex
* include how_to_enter_link in challenge api json

lib/web/templates/challenge/wizard/_how_to_enter.html.eex
* add language making clear filling in the field will redirect solvers

assets/client/src/components/ChallengeDetails.js
* adding logic to account for how_to_enter_link and redirection

test/web/controllers/api/challenge_controller_test.exs
* update test api json

- [ ] README is up to date
- [ ] Docs are up to date with changes (modules and functions)
- [ ] Tests are included for changes
- [ ] Links in emails use the `_url` route helpers
- [ ] Controllers modified contain appropriate authorization plugs
