### PR TITLE
Ensure halt after logout when used in pipeline

### DIFF
--- a/lib/web/controllers/session_controller.ex
+++ b/lib/web/controllers/session_controller.ex
@@ -131,7 +131,9 @@ defmodule Web.SessionController do
     timeout_at = get_session(conn, :session_timeout_at)
 
     if timeout_at && now() > timeout_at do
-      logout_user(conn)
+      conn
+      |> logout_user()
+      |> halt()
     else
       put_session(conn, :session_timeout_at, new_session_timeout_at(opts[:timeout_after_minutes]))
     end


### PR DESCRIPTION
Session timeout check is used as a plug and a route, need to ensure that
when it is used as a plug, it halt's the connection so as to not then
try and continue redirecting or rendering after the logout. This was
causing log noise.

- [x] README is up to date
- [x] Docs are up to date with changes (modules and functions)
- [ ] Tests are included for changes
- [x] Links in emails use the `_url` route helpers
- [x] Controllers modified contain appropriate authorization plugs
