### PR TITLE
Fix submission export memory issue

### DIFF
--- a/lib/challenge_gov/submissions/submission_export.ex
+++ b/lib/challenge_gov/submissions/submission_export.ex
@@ -16,7 +16,8 @@ defmodule ChallengeGov.Submissions.SubmissionExport do
     %{id: "pending", label: "Draft"},
     %{id: "cancelled", label: "Cancelled"},
     %{id: "completed", label: "Submitted"},
-    %{id: "outdated", label: "Outdated"}
+    %{id: "outdated", label: "Outdated"},
+    %{id: "error", label: "Error"}
   ]
 
   @judging_statuses [

--- a/lib/challenge_gov/submissions/submission_export_worker.ex
+++ b/lib/challenge_gov/submissions/submission_export_worker.ex
@@ -57,41 +57,66 @@ defmodule ChallengeGov.Submissions.SubmissionExportWorker do
   end
 
   defp export_submissions(submission_export, ".zip", submissions) do
+    # Setup initial directories and files and clear old ones
+    submission_exports_directory = "tmp/submission_exports/"
+
+    zip_file_path = "#{submission_export.id}.zip"
+    tmp_file_directory = submission_exports_directory <> "#{submission_export.id}/"
+
+    File.rm(zip_file_path)
+    File.rm_rf(tmp_file_directory)
+
+    File.mkdir_p(tmp_file_directory)
+
+    # Write CSV file to tmp directory
     csv = SubmissionExportView.submission_csv(submissions)
 
-    zip_files =
+    File.write!(tmp_file_directory <> "submissions.csv", to_string(csv))
+
+    # Write submission downloads to tmp directory
+    _zip_files =
       Enum.flat_map(submissions, fn submission ->
         Enum.map(submission.documents, fn document ->
           {:ok, document_download} = Storage.download(SubmissionDocuments.document_path(document))
 
-          document_path =
-            "/submissions/#{submission.id}/#{DocumentView.filename(document)}#{document.extension}"
+          document_path = tmp_file_directory <> "submissions/#{submission.id}/"
+          File.mkdir_p(document_path)
+          document_filename = "#{DocumentView.filename(document)}#{document.extension}"
 
-          data = File.read!(document_download)
+          File.cp!(document_download, document_path <> document_filename)
           File.rm(document_download)
-
-          {String.to_charlist(document_path), data}
         end)
       end)
 
-    zip_files = [{'submissions.csv', to_string(csv)} | zip_files]
+    # Attempt to zip tmp file directory
+    case Porcelain.exec("zip", ["-r", zip_file_path, tmp_file_directory]) do
+      %{status: 0} ->
+        file = Storage.prep_file(%{path: zip_file_path})
 
-    {:ok, zip_file_path} = Temp.create(extname: ".zip")
-    {:ok, _zip} = :zip.create(String.to_charlist(zip_file_path), zip_files)
+        path = SubmissionExports.document_path(submission_export.key, ".zip")
 
-    file = Storage.prep_file(%{path: zip_file_path})
+        meta = [
+          {:content_disposition, ~s{attachment; filename="submission-export.zip"}}
+        ]
 
-    path = SubmissionExports.document_path(submission_export.key, ".zip")
+        # Attempt to upload zip file
+        case Storage.upload(file, path, meta: meta) do
+          :ok ->
+            # Remove tmp files
+            File.rm(zip_file_path)
+            File.rm_rf(tmp_file_directory)
 
-    meta = [
-      {:content_disposition, ~s{attachment; filename="submission-export.zip"}}
-    ]
+            submission_export
+            |> Ecto.Changeset.change(%{status: "completed"})
+            |> Repo.update()
+        end
 
-    case Storage.upload(file, path, meta: meta) do
-      :ok ->
-        submission_export
-        |> Ecto.Changeset.change(%{status: "completed"})
-        |> Repo.update()
+      _ ->
+        # Remove tmp files
+        File.rm(zip_file_path)
+        File.rm_rf(tmp_file_directory)
+
+        {:error, :zip}
     end
   end
 end

--- a/lib/web/views/submission_export_view.ex
+++ b/lib/web/views/submission_export_view.ex
@@ -54,6 +54,12 @@ defmodule Web.SubmissionExportView do
           to: Routes.submission_export_path(conn, :delete, submission_export.id),
           method: "delete"
         )
+
+      "error" ->
+        link("Restart",
+          to: Routes.submission_export_path(conn, :restart, submission_export.id),
+          method: "post"
+        )
     end
   end
 


### PR DESCRIPTION
Fixes memory issue with submission exports when there are a lot of
documents to store in memory. Writes files to a directory and then zips
them instead
