### PR TITLE
Allow for submission sorting on id

### DIFF
--- a/lib/challenge_gov/submissions.ex
+++ b/lib/challenge_gov/submissions.ex
@@ -571,6 +571,26 @@ defmodule ChallengeGov.Submissions do
     end
   end
 
+  def order_on_attribute(query, sort_columns = %{"id" => _id}) do
+    columns_to_sort =
+      Enum.reduce(sort_columns, [], fn {column, direction}, acc ->
+        column = String.to_atom(column)
+
+        case direction do
+          "asc" ->
+            acc ++ [asc_nulls_last: column]
+
+          "desc" ->
+            acc ++ [desc_nulls_last: column]
+
+          _ ->
+            []
+        end
+      end)
+
+    order_by(query, [c], ^columns_to_sort)
+  end
+
   def order_on_attribute(query, sort_columns)
       when is_map(sort_columns) and map_size(sort_columns) > 0 do
     %{direction: direction, column: column} =


### PR DESCRIPTION
Create an id specific function head for submissions order_on_attribute

- [ ] README is up to date
- [ ] Docs are up to date with changes (modules and functions)
- [ ] Tests are included for changes
- [ ] Links in emails use the `_url` route helpers
- [ ] Controllers modified contain appropriate authorization plugs
