### PR TITLE
Updated preview for external challenge

### DIFF
--- a/assets/client/src/pages/PreviewPage.js
+++ b/assets/client/src/pages/PreviewPage.js
@@ -47,12 +47,29 @@ export const PreviewPage = () => {
   const renderPreviewItems = () => {
     if (print) {
       return (
+        <>
+          <div className="floating-tile">
+            <ChallengeTile challenge={currentChallenge} preview={true} loading={loadingState}/>
+          </div>
+          <div className="row">
+            <div className="col">
+              <ChallengeDetails ref={print && launchPrintDialogue()} challenge={currentChallenge} challengePhases={challengePhases} preview={true} loading={loadingState} print={print} tab={tab} />
+            </div>
+          </div>
+        </>
+      )
+    }
+
+    if (currentChallenge && currentChallenge.external_url) {
+      return (
         <div className="floating-tile">
           <ChallengeTile challenge={currentChallenge} preview={true} loading={loadingState}/>
         </div>
       )
-    } else {
-      return (
+    }
+
+    return (
+      <>
         <div className="challenge-preview__top row mb-5">
           <div className="col-md-4">
             <ChallengeTile challenge={currentChallenge} preview={true} loading={loadingState}/>
@@ -61,18 +78,18 @@ export const PreviewPage = () => {
             <PreviewBanner challenge={currentChallenge} />
           </div>
         </div>
-      )
-    }
+        <div className="row">
+          <div className="col">
+            <ChallengeDetails ref={print && launchPrintDialogue()} challenge={currentChallenge} challengePhases={challengePhases} preview={true} loading={loadingState} print={print} tab={tab} />
+          </div>
+        </div>
+      </>
+    )
   }
 
   return (
     <div className="challenge-preview py-5">
       {renderPreviewItems()}
-      <div className="row">
-        <div className="col">
-          <ChallengeDetails ref={print && launchPrintDialogue()} challenge={currentChallenge} challengePhases={challengePhases} preview={true} loading={loadingState} print={print} tab={tab} />
-        </div>
-      </div>
     </div>
   )
 }


### PR DESCRIPTION
Update challenge preview: if external url, show only tile

#### Note
'print' should not interfere since that button is only available from the details page, which does not show for externally hosted challenges

- [ ] README is up to date
- [ ] Docs are up to date with changes (modules and functions)
- [ ] Tests are included for changes
- [ ] Links in emails use the `_url` route helpers
- [ ] Controllers modified contain appropriate authorization plugs
