### PR TITLE
Tweaks/agency logo site management datetime

### DIFF
--- a/assets/client/src/components/ChallengeDetails.js
+++ b/assets/client/src/components/ChallengeDetails.js
@@ -235,7 +235,7 @@ export const ChallengeDetails = ({challenge, challengePhases, preview, print, ta
             <div className="social-share-btn" id="shareChallengeButton">
               <span className="details__btn">
                 <i className="fas fa-share-alt mr-2"></i>
-                share
+                Share
               </span>
               <SocialSharingTooltip shareTooltipOpen={shareTooltipOpen} toggleShareTooltip={toggleShareTooltip} challenge={challenge}/>
             </div>

--- a/assets/client/src/components/ChallengeTile.js
+++ b/assets/client/src/components/ChallengeTile.js
@@ -94,10 +94,10 @@ export const ChallengeTile = ({challenge, preview}) => {
   }
 
   const challengeTileUrl = (challenge, preview) => {
-    if (preview) {
-      return "#"
-    } else if (challenge.external_url) {
+    if (challenge.external_url) {
       return challenge.external_url
+    } else if (preview) {
+      return "#"
     } else {
       return `${publicUrl}/?challenge=${challenge.custom_url || challenge.id}`
     }

--- a/assets/client/src/components/PreviewBanner.js
+++ b/assets/client/src/components/PreviewBanner.js
@@ -1,8 +1,10 @@
-import React from 'react'
+import React, { useContext } from 'react'
 import moment from 'moment'
+import { ApiUrlContext } from '../ApiUrlContext'
 
 export const PreviewBanner = ({challenge}) => {
   const location = window.location.href.split('?')[0]
+  const { apiUrl } = useContext(ApiUrlContext)
 
   return (
     challenge ? (
@@ -20,7 +22,9 @@ export const PreviewBanner = ({challenge}) => {
             <div>
               <span className="mr-3">Preview generated on {moment().format("llll")}</span>
               <a className="mr-3" href={window.location.href}>Refresh page</a>
-              <a href={location + "?print=true"}>Print</a>
+              {!challenge.external_url &&
+                <a href={apiUrl + `/public/previews/challenges?challenge=${challenge.uuid}&print=true`} target="_blank">Print</a>
+              }
             </div> 
             <br/>
             <div>Link to share for internal agency review:</div>

--- a/assets/client/src/pages/PreviewPage.js
+++ b/assets/client/src/pages/PreviewPage.js
@@ -62,8 +62,13 @@ export const PreviewPage = () => {
 
     if (currentChallenge && currentChallenge.external_url) {
       return (
-        <div className="floating-tile">
-          <ChallengeTile challenge={currentChallenge} preview={true} loading={loadingState}/>
+        <div className="challenge-preview__top row mb-5">
+          <div className="col-md-4">
+            <ChallengeTile challenge={currentChallenge} preview={true} loading={loadingState}/>
+          </div>
+          <div className="col-md-8">
+            <PreviewBanner challenge={currentChallenge} />
+          </div>
         </div>
       )
     }

--- a/lib/web/templates/challenge/wizard/_how_to_enter.html.eex
+++ b/lib/web/templates/challenge/wizard/_how_to_enter.html.eex
@@ -14,5 +14,5 @@
 <div class="col">
   <%= FormView.text_field(@form, :how_to_enter_link, label: "External website how-to-enter link (optional)") %>
 </div>
-<p class="ml-2 text-muted"><b>How to Enter:</b> Provide the website URL or email address that is specific to any entry guidelines.</p>
+<p class="ml-2 text-muted"><b>How to Enter:</b> Provide the website URL that is specific to any entry guidelines.</p>
 <p class="ml-2 text-muted">Solvers will be redirected to this url when applying if filled in</p>

--- a/lib/web/templates/layout/app.html.eex
+++ b/lib/web/templates/layout/app.html.eex
@@ -66,7 +66,7 @@
               <div class="callout callout-warning">
                 <i class="fa fa-exclamation-circle"></i>
                 <span class="ql-editor">
-                  <%= raw @conn.assigns.site_wide_banner.content %>
+                  <span><%= raw (@conn.assigns.site_wide_banner.content) %></span>
                 </span>
               </span>
             </div>

--- a/lib/web/templates/layout/public.html.eex
+++ b/lib/web/templates/layout/public.html.eex
@@ -18,7 +18,7 @@
                 <div class="callout callout-warning">
                   <i class="fa fa-exclamation-circle"></i>
                   <span class="ql-editor">
-                    <%= raw @conn.assigns.site_wide_banner.content %>
+                    <span><%= raw (@conn.assigns.site_wide_banner.content) %></span>
                   </span>
                 </span>
               </div>

--- a/lib/web/templates/site_content/_form.html.eex
+++ b/lib/web/templates/site_content/_form.html.eex
@@ -2,8 +2,18 @@
   <div class="card-body">
     <%= FormView.rt_textarea_field(f, :content) %>
     <%= if @section === "site_wide_banner" do %>
-      <%= FormView.datetime_field(f, :start_date) %>
-      <%= FormView.datetime_field(f, :end_date) %>
+      <div class="w-25 d-flex">
+        <div class="mr-4">
+          <label class="control-label">Start date</label>
+          <%= ChallengeView.date_and_time_inputs(@conn, f, :start_date, "Start date", "site_banner_start") %>
+          <%= hidden_input(f, :start_date, label: "Start date") %>
+        </div>
+        <div>
+          <label class="control-label">End date</label>
+          <%= ChallengeView.date_and_time_inputs(@conn, f, :end_date, "End date", "site_banner_end") %>
+          <%= hidden_input(f, :end_date, label: "End date") %>
+      </div>
+      </div>
     <% end %>
   </div>
 

--- a/lib/web/templates/site_content/edit.html.eex
+++ b/lib/web/templates/site_content/edit.html.eex
@@ -21,7 +21,7 @@
     <div class="row">
       <div class="col-md-12">
         <div class="card">        
-          <%= render Web.SiteContentView, "_form.html", changeset: @changeset, data: @changeset.data, section: @content.section, path: Routes.site_content_path(@conn, :update, @content.section) %>
+          <%= render Web.SiteContentView, "_form.html", conn: @conn, changeset: @changeset, data: @changeset.data, section: @content.section, path: Routes.site_content_path(@conn, :update, @content.section) %>
         </div>
       </div>
     </div>

--- a/lib/web/templates/site_content/show.html.eex
+++ b/lib/web/templates/site_content/show.html.eex
@@ -32,27 +32,33 @@
 
             <dt>Content</dd>
             <dd>
-              <%= SharedView.render_safe_html(@content.content) %>
+              <div class="editor-text-reset"><%= SharedView.render_safe_html(@content.content) %></div>
             </dd>
             <br/>
 
-            <%= if @content.section === "site_wide_banner" and @content.start_date do %>
-              <dt>
-                <span class="text-bold">Start date: </span>
-              </dt>
-              <dd>
-                <span class="js-local-datetime"><%= @content.start_date %></span>
-              </dd>
-            <% end %>
+            <div class="d-flex">
+              <%= if @content.section === "site_wide_banner" and @content.start_date do %>
+                <div class="mr-4">
+                  <dt>
+                    <span class="text-bold">Start date: </span>
+                  </dt>
+                  <dd>
+                    <span class="js-local-datetime"><%= @content.start_date %></span>
+                  </dd>
+                </div>
+              <% end %>
 
-            <%= if @content.section === "site_wide_banner" and @content.end_date do %>
-              <dt>
-                <span class="text-bold">End date: </span>
-              </dt>
-              <dd>
-                <span class="js-local-datetime"><%= @content.end_date %></span>
-              </dd>
-            <% end %>
+              <%= if @content.section === "site_wide_banner" and @content.end_date do %>
+                <div>
+                  <dt>
+                    <span class="text-bold">End date: </span>
+                  </dt>
+                  <dd>
+                    <span class="js-local-datetime"><%= @content.end_date %></span>
+                  </dd>
+                </div>
+              <% end %>
+            </div>
           </div>
         </div>
       </div>

--- a/lib/web/views/form_view.ex
+++ b/lib/web/views/form_view.ex
@@ -397,10 +397,15 @@ defmodule Web.FormView do
     classes = form_control_file_classes(form, field)
 
     label =
-      if opts[:label] === false do
-        ""
-      else
-        label(form, field, class: "col-md-4")
+      cond do
+        opts[:label] ->
+          label(form, field, opts[:label], class: "col-md-4")
+
+        opts[:label] === false ->
+          ""
+
+        true ->
+          label(form, field, class: "col-md-4")
       end
 
     class =

--- a/lib/web/views/site_content_view.ex
+++ b/lib/web/views/site_content_view.ex
@@ -3,4 +3,5 @@ defmodule Web.SiteContentView do
 
   alias Web.FormView
   alias Web.SharedView
+  alias Web.ChallengeView
 end


### PR DESCRIPTION
- vertically center site wide banner text
- update and correct datetime pickers/handling for site wide banner
<img width="663" alt="Screen Shot 2021-12-07 at 3 53 06 PM" src="https://user-images.githubusercontent.com/13442896/145252694-3405b940-9070-4c69-aba5-9829119d9867.png">

- make file_field labelling more flexible and correct

<img width="370" alt="Screen Shot 2021-12-07 at 3 53 42 PM" src="https://user-images.githubusercontent.com/13442896/145252695-3a8128a5-7660-4114-b2d3-dfc5d278405e.png">

- capitalize share button text (match follow)
- update externally hosted challenge previews: banner/link/print link
- remove 'email address' from how to enter link helper text
