### PR TITLE
Possible fixes for session timeout ireegularities

### DIFF
--- a/lib/web/controllers/page_controller.ex
+++ b/lib/web/controllers/page_controller.ex
@@ -20,6 +20,10 @@ defmodule Web.PageController do
         conn
         |> put_flash(:info, "Login successful")
         |> put_session(:user_token, user.token)
+        |> put_session(
+          :session_timeout_at,
+          Web.SessionController.new_session_timeout_at(ChallengeGov.Security.timeout_interval())
+        )
         |> redirect(to: Routes.dashboard_path(conn, :index))
 
       {:error, _err} ->

--- a/lib/web/controllers/session_controller.ex
+++ b/lib/web/controllers/session_controller.ex
@@ -128,15 +128,16 @@ defmodule Web.SessionController do
   @doc """
   session timeout and reset
   """
-  def check_session_timeout(conn, opts) do
+  def check_session_timeout(conn, _opts_or_params) do
     timeout_at = get_session(conn, :session_timeout_at)
+    timeout_after_minutes = Security.timeout_interval()
 
     if timeout_at do
       if now() < timeout_at do
         put_session(
           conn,
           :session_timeout_at,
-          new_session_timeout_at(opts[:timeout_after_minutes])
+          new_session_timeout_at(timeout_after_minutes)
         )
       else
         conn

--- a/lib/web/views/shared_view.ex
+++ b/lib/web/views/shared_view.ex
@@ -5,7 +5,7 @@ defmodule Web.SharedView do
   alias Web.SharedView
 
   def session_timeout(conn) do
-    Map.get(conn.private.plug_session, "session_timeout_at")
+    Plug.Conn.get_session(conn, "session_timeout_at")
   end
 
   def public_page_path(path, page, pagination_param \\ nil) do

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -35,6 +35,15 @@ defmodule Web.ConnCase do
       Ecto.Adapters.SQL.Sandbox.mode(ChallengeGov.Repo, {:shared, self()})
     end
 
-    {:ok, conn: Phoenix.ConnTest.build_conn()}
+    # TODO: Fix test failures due to changes in session_timeout code by adding one globally
+    # Possibly refactor this later to be used in more specific tests or a test helper
+    conn =
+      Phoenix.ConnTest.build_conn()
+      |> Plug.Test.init_test_session(
+        session_timeout_at:
+          Web.SessionController.new_session_timeout_at(ChallengeGov.Security.timeout_interval())
+      )
+
+    {:ok, conn: conn}
   end
 end

--- a/test/web/controllers/message_context_controller_test.exs
+++ b/test/web/controllers/message_context_controller_test.exs
@@ -487,7 +487,7 @@ defmodule Web.MessageContextControllerTest do
           "message_context" => message_context_attributes
         })
 
-      assert {:ok, context} = MessageContexts.get("challenge", challenge.id, "all")
+      assert {:ok, _context} = MessageContexts.get("challenge", challenge.id, "all")
 
       assert get_flash(conn, :error) == "You can not start a message thread"
       assert html_response(conn, 302)

--- a/test/web/controllers/saved_challenge_controller_test.exs
+++ b/test/web/controllers/saved_challenge_controller_test.exs
@@ -4,7 +4,6 @@ defmodule Web.SavedChallengeControllerTest do
   alias ChallengeGov.SavedChallenges
   alias ChallengeGov.TestHelpers.AccountHelpers
   alias ChallengeGov.TestHelpers.ChallengeHelpers
-  alias Web.ChallengeView
 
   describe "index for saved challenges" do
     test "successfully retrieve all saved challenges for current user", %{conn: conn} do


### PR DESCRIPTION
Add a session timeout value to the session when a user logs in. Add an
extra case on most authenticated routes to log the user out if they
don't have a session timeout value
