### PR TITLE
Scrub HTML from CSV Export

### DIFF
--- a/lib/web/views/export_view.ex
+++ b/lib/web/views/export_view.ex
@@ -20,8 +20,21 @@ defmodule Web.ExportView do
   end
 
   def challenge_csv(challenge) do
-    CSV.dump_to_iodata([csv_headers(challenge), csv_content(challenge)])
+    scrubbed_challenge =
+      challenge
+      |> csv_content()
+      |> remove_html_markup([])
+
+    CSV.dump_to_iodata([csv_headers(challenge), scrubbed_challenge])
   end
+
+  def remove_html_markup([head | rest], acc) when is_binary(head),
+    do: remove_html_markup(rest, acc ++ [scrub(head)])
+
+  def remove_html_markup([head | rest], acc), do: remove_html_markup(rest, acc ++ [head])
+  def remove_html_markup([], acc), do: acc
+
+  defp scrub(data), do: String.replace(data, ~r/<[^>]*>/, "")
 
   defp csv_headers(challenge) do
     [

--- a/test/web/views/export_view_test.exs
+++ b/test/web/views/export_view_test.exs
@@ -46,5 +46,34 @@ defmodule Web.ExportViewTest do
 
       assert ExportView.format_content(challenge, "invalid") === {:error, :invalid_format}
     end
+
+    test "given brief_description has html, we strip the html" do
+      user = AccountHelpers.create_user()
+
+      challenge =
+        ChallengeHelpers.create_challenge(
+          %{
+            user_id: user.id,
+            brief_description: "<p>Test <b>brief</b> description from test</p>",
+            description: "<h1>Test <i>description</i> for a challenge from test</h1>"
+          },
+          user
+        )
+
+      {:ok, challenge} = Challenges.get(challenge.id)
+
+      {:ok, content} = ExportView.format_content(challenge, "csv")
+
+      flattened_content = List.flatten(content)
+
+      assert Enum.member?(flattened_content, "Test brief description from test")
+      refute Enum.member?(flattened_content, "<p>Test <b>brief</b> description from test</p>")
+      assert Enum.member?(flattened_content, "Test description for a challenge from test")
+
+      refute Enum.member?(
+               flattened_content,
+               "<h1>Test <i>description</i> for a challenge from test</h1>"
+             )
+    end
   end
 end


### PR DESCRIPTION
Scrubbed HTML tags from CSV export.
Issue [CHAL-843](https://cm-jira.usa.gov/browse/CHAL-843?filter=-5&jql=project%20%3D%20CHAL%20AND%20resolution%20%3D%20Unresolved%20AND%20assignee%20in%20(currentUser())%20order%20by%20priority%20DESC%2Cupdated%20DESC)

- [x] Tests are included for changes
