### PR TITLE
Send account activation email when a solver creates an account

### DIFF
--- a/lib/web/controllers/user_controller.ex
+++ b/lib/web/controllers/user_controller.ex
@@ -220,12 +220,11 @@ defmodule Web.UserController do
 
   def toggle(conn, %{"id" => id, "action" => "activate"}) do
     # TODO - this sends two emails, but I only want one.
-    # IO.inspect("I hit a toggle???")
     %{current_user: originator} = conn.assigns
 
     with {:ok, user} <- Accounts.get(id),
          {:ok, user} <- Accounts.activate(user, originator, Security.extract_remote_ip(conn)) do
-      Emails.account_reactivation(user)
+      # Emails.account_reactivation(user)
 
       conn
       |> put_flash(:info, "User activated")


### PR DESCRIPTION
This is a cherry-picked rebuild of the original feature.  Merging it in for testing.
