### PR TITLE
Fix analytics total cash prizes graph

### DIFF
--- a/lib/challenge_gov/analytics.ex
+++ b/lib/challenge_gov/analytics.ex
@@ -110,7 +110,7 @@ defmodule ChallengeGov.Analytics do
   end
 
   def calculate_prize_amount(challenge = %{imported: true}), do: challenge.prize_total || 0
-  def calculate_prize_amount(challenge), do: (challenge.prize_total || 0) / 1000
+  def calculate_prize_amount(challenge), do: (challenge.prize_total || 0) / 100
 
   def all_challenges(challenges, years) do
     challenges = challenge_prefilter(challenges)
@@ -267,7 +267,10 @@ defmodule ChallengeGov.Analytics do
   end
 
   def total_cash_prizes(challenges, years) do
-    challenges = challenge_prefilter(challenges)
+    challenges =
+      challenges
+      |> challenge_prefilter()
+      |> Enum.reject(fn c -> c.status not in ["published", "archived"] end)
 
     data =
       years


### PR DESCRIPTION
Previously the graph indicated an incorrect monetary value for two reasons
1. The analytics included all challenges of all statuses which have now been changed to only include archived and active
2. The analytics number was being divided by 1000 rather than 100. The 100 intended to alter cents to dollar amount.

- [ ] README is up to date
- [ ] Docs are up to date with changes (modules and functions)
- [ ] Tests are included for changes
- [ ] Links in emails use the `_url` route helpers
- [ ] Controllers modified contain appropriate authorization plugs
