### PR TITLE
CHAL-1146 Messaging internal server error

### DIFF
--- a/lib/web/views/message_context_view.ex
+++ b/lib/web/views/message_context_view.ex
@@ -66,8 +66,10 @@ defmodule Web.MessageContextView do
 
   def challenge_url(%{role: "solver"}, challenge), do: ChallengeView.public_details_url(challenge)
 
-  def challenge_url(_user, challenge),
-    do: Routes.challenge_path(Web.Endpoint, :show, challenge.id)
+  def challenge_url(_user, %{id: id}),
+    do: Routes.challenge_path(Web.Endpoint, :show, id)
+
+  def challenge_url(_user, _), do: nil
 
   def display_last_author_name(message_context) do
     last_author = get_last_author(message_context)


### PR DESCRIPTION
MessageContexts.get_context_record was recieving a map with context: challenge, but no challenge wasfound for the record>
The function's pattern match did not allow for error not not found.

- [ ] README is up to date
- [ ] Docs are up to date with changes (modules and functions)
- [ ] Tests are included for changes
- [ ] Links in emails use the `_url` route helpers
- [ ] Controllers modified contain appropriate authorization plugs
