### PR TITLE
Fix Timeline Event Sorting Break

### DIFF
--- a/lib/challenge_gov/challenges.ex
+++ b/lib/challenge_gov/challenges.ex
@@ -477,12 +477,16 @@ defmodule ChallengeGov.Challenges do
           |> Map.put(
             :timeline_events,
             challenge.timeline_events
+            |> remove_nil_dates()
             |> Enum.sort(&(DateTime.compare(&1.date, &2.date) != :gt))
           )
 
         {:ok, challenge}
     end
   end
+
+  def remove_nil_dates(events) when is_list(events),
+    do: Enum.reject(events, fn e -> is_nil(e.date) end)
 
   @doc """
   Get a challenge by uuid

--- a/test/challenge_gov/challenges/challenge_timeline_events_test.exs
+++ b/test/challenge_gov/challenges/challenge_timeline_events_test.exs
@@ -52,7 +52,8 @@ defmodule ChallengeGov.ChallengeTimelineEventsTest do
               "section" => "timeline",
               "timeline_events" => %{
                 "0" => %{
-                  "title" => "Test"
+                  "title" => "Test",
+                  "date" => DateTime.utc_now()
                 }
               }
             }


### PR DESCRIPTION
Occasionally dates for events are nil, which causes a break in DateTime.compare/2. This fix removes all records that have nil dates from the sort list

- [ ] README is up to date
- [ ] Docs are up to date with changes (modules and functions)
- [ ] Tests are included for changes
- [ ] Links in emails use the `_url` route helpers
- [ ] Controllers modified contain appropriate authorization plugs
