### PR TITLE
Decertification Function Change

### DIFF
--- a/lib/challenge_gov/certification_logs.ex
+++ b/lib/challenge_gov/certification_logs.ex
@@ -45,8 +45,6 @@ defmodule ChallengeGov.CertificationLogs do
   end
 
   def check_for_expired_certifications do
-    two_days_ago = Timex.shift(Timex.now(), days: -2)
-
     # get records where user is not decertified and expiry is past now
     results =
       CertificationLog
@@ -58,7 +56,6 @@ defmodule ChallengeGov.CertificationLogs do
           user.role != "solver"
       )
       |> where([r], is_nil(r.requested_at))
-      |> where([r], r.updated_at > ^two_days_ago)
       |> order_by([r], desc: r.updated_at)
       |> Repo.all()
 


### PR DESCRIPTION
The decertification automated process checks to see if a record has been updated greater than 2 days prior. This check seems to interfere with assuring all records in need of decertification have the status changed. The time requirement is being removed to ensure more records are retrieved for change.
