### PR TITLE
CHAL-1261 Security Log Fix

### DIFF
--- a/lib/challenge_gov/accounts.ex
+++ b/lib/challenge_gov/accounts.ex
@@ -912,7 +912,7 @@ defmodule ChallengeGov.Accounts do
         SecurityLogs.track(%{
           target_id: user.id,
           target_type: user.role,
-          target_identifier: user.role,
+          target_identifier: user.email,
           action: "status_change",
           details: %{previous_status: previous_status, new_status: "decertified"}
         })


### PR DESCRIPTION
On decertification, security logs are recording user type is being recorded in both the "Target Type" and "Target Identifier" fields. The user email address should go into the "Target Identifier" field.

