### PR TITLE
Remove WYSIYG from Challenge Brief Description

### DIFF
--- a/lib/challenge_gov/challenges/challenge.ex
+++ b/lib/challenge_gov/challenges/challenge.ex
@@ -465,8 +465,6 @@ defmodule ChallengeGov.Challenges.Challenge do
     ])
     |> validate_length(:title, max: 90)
     |> validate_length(:tagline, max: 400)
-    |> validate_rich_text_length(:brief_description, 200)
-    |> validate_rich_text_length(:description, 15_000)
     |> validate_length(:other_type, max: 45)
     |> validate_inclusion(:primary_type, @challenge_types)
     |> maybe_validate_types(params)
@@ -474,23 +472,6 @@ defmodule ChallengeGov.Challenges.Challenge do
     |> validate_auto_publish_date(params)
     |> validate_custom_url(params)
     |> validate_phases(params)
-  end
-
-  def validate_rich_text_length(struct, field, length) do
-    field_length = String.to_existing_atom("#{field}_length")
-    value = get_field(struct, field_length)
-
-    case value do
-      nil ->
-        struct
-
-      _ ->
-        if value > length do
-          add_error(struct, field, "can't be greater than #{length} characters")
-        else
-          struct
-        end
-    end
   end
 
   def timeline_changeset(struct, params) do

--- a/lib/challenge_gov/submissions/submission.ex
+++ b/lib/challenge_gov/submissions/submission.ex
@@ -104,7 +104,6 @@ defmodule ChallengeGov.Submissions.Submission do
     |> foreign_key_constraint(:phase)
     |> foreign_key_constraint(:manager)
     |> validate_inclusion(:status, status_ids())
-    |> validate_rich_text_length(:brief_description, 500)
   end
 
   def review_changeset(struct, params, user, challenge, phase) do
@@ -127,7 +126,6 @@ defmodule ChallengeGov.Submissions.Submission do
       :brief_description,
       :description
     ])
-    |> validate_rich_text_length(:brief_description, 500)
   end
 
   def update_draft_changeset(struct, params) do
@@ -139,7 +137,6 @@ defmodule ChallengeGov.Submissions.Submission do
     |> foreign_key_constraint(:phase)
     |> foreign_key_constraint(:manager)
     |> validate_inclusion(:status, status_ids())
-    |> validate_rich_text_length(:brief_description, 500)
   end
 
   def update_review_changeset(struct, params) do
@@ -158,7 +155,6 @@ defmodule ChallengeGov.Submissions.Submission do
       :brief_description,
       :description
     ])
-    |> validate_rich_text_length(:brief_description, 500)
   end
 
   def submit_changeset(struct) do
@@ -183,23 +179,6 @@ defmodule ChallengeGov.Submissions.Submission do
     struct
     |> change()
     |> put_change(:deleted_at, now)
-  end
-
-  def validate_rich_text_length(struct, field, length) do
-    field_length = String.to_existing_atom("#{field}_length")
-    value = get_field(struct, field_length)
-
-    case value do
-      nil ->
-        struct
-
-      _ ->
-        if value > length do
-          add_error(struct, field, "can't be greater than #{length} characters")
-        else
-          struct
-        end
-    end
   end
 
   defp validate_required_fields(struct) do

--- a/lib/web/templates/challenge/wizard/_details.html.eex
+++ b/lib/web/templates/challenge/wizard/_details.html.eex
@@ -93,15 +93,14 @@
 <br/>
 
 <div class="col">
-  <label for="brief_description">Short description (200 character limit)</label>
-  <%= FormView.rt_textarea_field(@form, :brief_description, limit: 200) %>
+  <%= FormView.text_field(@form, :brief_description, label: "Short description (200 character limit)", limit: 200) %>
   <p class="ms-2 text-muted">Provide a general overview of your challenge, including any background on the problem you’re trying to solve.</p>
 </div>
 
 <br/>
 
 <div class="col">
-  <label><%= "Long description (15000 character limit)" %> <span class="required">*</span></label>
+  <label>Long description (15000 character limit) <span class="required">*</span></label>
   <%= FormView.rt_textarea_field(@form, :description, limit: 15000) %>
   <p class="ms-2 text-muted">Provide a detailed overview of your challenge, including any background on the problem you’re trying to solve, and any key dates you want to highlight.</p>
 </div>


### PR DESCRIPTION
The WYSIYG was causing issues by adding html to the description and reducing the number of characters one could input into the field.

