### PR TITLE
CHAL-1286 Custom URL for challenge

### DIFF
--- a/lib/challenge_gov/challenges/challenge.ex
+++ b/lib/challenge_gov/challenges/challenge.ex
@@ -472,6 +472,7 @@ defmodule ChallengeGov.Challenges.Challenge do
     |> validate_upload_logo(params)
     |> validate_auto_publish_date(params)
     |> validate_custom_url(params)
+    |> validate_format(:custom_url, ~r/[a-zA-Z0-9_-]/)
     |> validate_phases(params)
   end
 

--- a/test/integration/challenge_test.exs
+++ b/test/integration/challenge_test.exs
@@ -74,7 +74,6 @@ defmodule ChallengeGov.ChallengeIntegrationTest do
     session
     |> populate_start_date("challenge_phases_0_start_date")
     |> populate_end_date("challenge_phases_0_end_date")
-    # |> assert_text("Next")
     |> touch_scroll(button("Next"), 0, 1)
     |> click(css(".btn-testing"))
   end


### PR DESCRIPTION
Disallow any non-alphanumerics with exception of - and _ in teh custom url field for challenge details section.

- [ ] README is up to date
- [ ] Docs are up to date with changes (modules and functions)
- [ ] Tests are included for changes
- [ ] Links in emails use the `_url` route helpers
- [ ] Controllers modified contain appropriate authorization plugs
