### PR TITLE
CHAL-1286 Custom URL for challenge

### DIFF
--- a/lib/challenge_gov/challenges/challenge.ex
+++ b/lib/challenge_gov/challenges/challenge.ex
@@ -473,7 +473,24 @@ defmodule ChallengeGov.Challenges.Challenge do
     |> validate_upload_logo(params)
     |> validate_auto_publish_date(params)
     |> validate_custom_url(params)
+    |> validate_custom_url()
     |> validate_phases(params)
+  end
+
+  defp validate_custom_url(changeset) do
+    url = Ecto.Changeset.get_field(changeset, :custom_url)
+
+    maybe_add_url_error(changeset, url)
+  end
+
+  defp maybe_add_url_error(changeset, nil), do: changeset
+
+  defp maybe_add_url_error(changeset, url) do
+    if Regex.match?(~r/[^a-z0-9\-]/, url) do
+      Ecto.Changeset.add_error(changeset, :custom_url, "URL Contains Invalid Character(s).")
+    else
+      changeset
+    end
   end
 
   def validate_rich_text_length(struct, field, length) do

--- a/test/integration/challenge_test.exs
+++ b/test/integration/challenge_test.exs
@@ -74,7 +74,6 @@ defmodule ChallengeGov.ChallengeIntegrationTest do
     session
     |> populate_start_date("challenge_phases_0_start_date")
     |> populate_end_date("challenge_phases_0_end_date")
-    # |> assert_text("Next")
     |> touch_scroll(button("Next"), 0, 1)
     |> click(css(".btn-testing"))
   end


### PR DESCRIPTION
Disallow any non-alphanumerics with exception of - and _ in teh custom url field for challenge details section.

- [ ] README is up to date
- [ ] Docs are up to date with changes (modules and functions)
- [ ] Tests are included for changes
- [ ] Links in emails use the `_url` route helpers
- [ ] Controllers modified contain appropriate authorization plugs
