### PR TITLE
CHAL-1286 Custom URL for challenge

### DIFF
--- a/lib/challenge_gov/challenges/challenge.ex
+++ b/lib/challenge_gov/challenges/challenge.ex
@@ -472,7 +472,41 @@ defmodule ChallengeGov.Challenges.Challenge do
     |> validate_upload_logo(params)
     |> validate_auto_publish_date(params)
     |> validate_custom_url(params)
+    |> validate_custom_url()
     |> validate_phases(params)
+  end
+
+  defp validate_custom_url(changeset) do
+    url = Ecto.Changeset.get_field(changeset, :custom_url)
+
+    maybe_add_url_error(changeset, url)
+  end
+
+  defp maybe_add_url_error(changeset, nil), do: changeset
+
+  defp maybe_add_url_error(changeset, url) do
+    if Regex.match?(~r/[^a-z0-9\-]/, url) do
+      Ecto.Changeset.add_error(changeset, :custom_url, "URL Contains Invalid Character(s).")
+    else
+      changeset
+    end
+  end
+
+  def validate_rich_text_length(struct, field, length) do
+    field_length = String.to_existing_atom("#{field}_length")
+    value = get_field(struct, field_length)
+
+    case value do
+      nil ->
+        struct
+
+      _ ->
+        if value > length do
+          add_error(struct, field, "can't be greater than #{length} characters")
+        else
+          struct
+        end
+    end
   end
 
   def timeline_changeset(struct, params) do

--- a/lib/web/templates/challenge/wizard/_details.html.eex
+++ b/lib/web/templates/challenge/wizard/_details.html.eex
@@ -65,7 +65,10 @@
 <div class="mb-3">
   <%= label @form, :custom_url, "Custom url (optional)", class: "col-md-4" %>
   <div class="ms-2">
-    <p class="ms-2 text-muted">If no custom URL is provided, the challenge URL will default to the challenge title.</p>
+    <p class="ms-2 text-muted">
+      URLs will be formatted as follows: https://www.challenge.gov/?challenge={challenge-specific-identifier}.  By default the challenge specific identifier be the challenge name.
+      You can set a custom challenge specific identifier in the box below. Do not use the following characters as they will cause the URL to be invalid:  {, }, |, \, /, ^, ~, [, ], `, &, %, :, #, ?, @, +
+    </p>
     <span><%= ChallengeView.public_details_root_url() %></span><span id="custom-url-example"></span>
   </div>
   <%= FormView.text_field(@form, :custom_url, label: nil, placeholder: "my-custom-challenge-name") %>

--- a/test/integration/challenge_test.exs
+++ b/test/integration/challenge_test.exs
@@ -74,7 +74,6 @@ defmodule ChallengeGov.ChallengeIntegrationTest do
     session
     |> populate_start_date("challenge_phases_0_start_date")
     |> populate_end_date("challenge_phases_0_end_date")
-    # |> assert_text("Next")
     |> touch_scroll(button("Next"), 0, 1)
     |> click(css(".btn-testing"))
   end


### PR DESCRIPTION
Disallow any non-alphanumerics with exception of - and in the custom url field for challenge details section.

