### PR TITLE
CHAL-1286 Custom URL for challenge

### DIFF
--- a/lib/web/templates/challenge/wizard/_details.html.eex
+++ b/lib/web/templates/challenge/wizard/_details.html.eex
@@ -65,7 +65,10 @@
 <div class="mb-3">
   <%= label @form, :custom_url, "Custom url (optional)", class: "col-md-4" %>
   <div class="ms-2">
-    <p class="ms-2 text-muted">If no custom URL is provided, the challenge URL will default to the challenge title.</p>
+    <p class="ms-2 text-muted">
+      URLs will be formatted as follows: https://www.challenge.gov/?challenge={challenge-specific-identifier}.  By default the challenge specific identifier be the challenge name.
+      You can set a custom challenge specific identifier in the box below. Only use alphanumeric characters and hyphens (-). Inclusion of other characters will cause the URL to be invalid.
+    </p>
     <span><%= ChallengeView.public_details_root_url() %></span><span id="custom-url-example"></span>
   </div>
   <%= FormView.text_field(@form, :custom_url, label: nil, placeholder: "my-custom-challenge-name") %>

--- a/test/integration/challenge_test.exs
+++ b/test/integration/challenge_test.exs
@@ -74,7 +74,6 @@ defmodule ChallengeGov.ChallengeIntegrationTest do
     session
     |> populate_start_date("challenge_phases_0_start_date")
     |> populate_end_date("challenge_phases_0_end_date")
-    # |> assert_text("Next")
     |> touch_scroll(button("Next"), 0, 1)
     |> click(css(".btn-testing"))
   end


### PR DESCRIPTION
Disallow any non-letters with exception of - in the custom url field for challenge details section.

- [ ] README is up to date
- [ ] Docs are up to date with changes (modules and functions)
- [ ] Tests are included for changes
- [ ] Links in emails use the `_url` route helpers
- [ ] Controllers modified contain appropriate authorization plugs
