### PR TITLE
CHAL-1291 Adjust Challenge Wizard Buttons

### DIFF
--- a/lib/web/controllers/challenge_controller.ex
+++ b/lib/web/controllers/challenge_controller.ex
@@ -219,11 +219,11 @@ defmodule Web.ChallengeController do
           |> put_flash(:info, "Challenge saved as draft")
           |> redirect(to: Routes.challenge_path(conn, :edit, challenge.id, section))
 
-        "return_to_review" ->
+        "save" ->
           conn
           |> put_flash(:info, "Changes saved")
           |> maybe_put_flash_subscriber_update(challenge)
-          |> redirect(to: Routes.challenge_path(conn, :show, challenge.id) <> "##{section}")
+          |> redirect(to: Routes.challenge_path(conn, :edit, challenge.id, section))
 
         "submit" ->
           conn

--- a/lib/web/templates/challenge/wizard.html.eex
+++ b/lib/web/templates/challenge/wizard.html.eex
@@ -59,13 +59,15 @@
               </div>
 
               <div class="card-footer">
-                <%= back_button(@conn, @changeset.data, @section) %>
-                <%= save_and_return_to_review_button(@section) %>
-                <%= cancel_button(@conn) %>
-                <%= submit_button(@section, @user) %>
-                <%= preview_challenge_button(@conn, @challenge, @section) %>
-                <%= save_draft_button(@challenge, @section) %>
-
+                <span class="mr-2">
+                  <%= previous_button(@conn, @changeset.data, @section) %>
+                </span>
+                <%= exit_button(@conn, @challenge) %>
+                <span class="float-right">
+                  <%= save_button(@section, @challenge) %>
+                  <%= preview_challenge_button(@conn, @challenge, @section) %>
+                  <%= next_or_submit(@section, @user, @challenge) %>
+                </span>
               </div>
             </div>
           <% end) %>

--- a/lib/web/views/challenge_view.ex
+++ b/lib/web/views/challenge_view.ex
@@ -512,79 +512,71 @@ defmodule Web.ChallengeView do
     end
   end
 
-  def back_button(conn, challenge, section) do
-    if section != Enum.at(Challenges.sections(), 0).id && !last_wizard_section?(section) do
+  def previous_button(conn, challenge, section) do
+    if section != Enum.at(Challenges.sections(), 0).id && !is_final_section?(section) do
       if challenge.id do
-        submit("Back", name: "action", value: "back", class: "btn btn-link", formnovalidate: true)
+        submit("Previous",
+          name: "action",
+          value: "back",
+          class: "btn btn-outline-primary px-5",
+          formnovalidate: true
+        )
       else
-        link("Back",
+        link("Previous",
           to: Routes.challenge_path(conn, :index),
-          class: "btn btn-link",
+          class: "btn btn-outline-primary",
           formnovalidate: true
         )
       end
     end
   end
 
-  def save_and_return_to_review_button(section) do
-    if !last_wizard_section?(section) do
-      submit("Save and return to review",
+  def save_button(section, challenge) do
+    if !is_final_section?(section) do
+      submit("Save",
         name: "action",
-        value: "return_to_review",
-        class: "usa-button"
+        value: "save",
+        class: "btn btn-primary px-5 mr-2",
+        data: [confirm: confirmation_message(:save, challenge)]
       )
     end
   end
 
-  def cancel_button(conn) do
-    link("cancel",
+  def exit_button(conn, challenge) do
+    link("Exit",
       to: Routes.challenge_path(conn, :index),
-      class: "btn btn-link",
+      class: "btn btn-outline-primary px-5",
+      data: [confirm: confirmation_message(:exit, challenge)],
       formnovalidate: true
     )
   end
 
-  def save_draft_button(challenge, section) do
-    challenge_open? =
-      !!challenge && challenge.status === "published" && challenge.sub_status === "open"
-
-    if section != Enum.at(Challenges.sections(), -1).id && !challenge_open? do
-      submit("Save Draft",
-        name: "action",
-        value: "save_draft",
-        class: "btn btn-link float-right",
-        formnovalidate: true
-      )
-    end
-  end
-
-  def last_wizard_section?(section) do
-    section == Enum.at(Challenges.sections(), -1).id
-  end
-
   def preview_challenge_button(conn, challenge, section) do
-    if last_wizard_section?(section) do
-      link("Preview",
+    if is_final_section?(section) do
+      link("Preview Challenge in New Tab",
         to: Routes.public_preview_path(conn, :index, challenge: challenge.uuid),
-        class: "usa-button float-right",
+        class: "btn btn-outline-primary px-5 mr-2",
         target: "_blank"
       )
     end
   end
 
-  def submit_button(section, user) do
-    last_section = section == Enum.at(Challenges.sections(), -1).id
+  def next_or_submit(section, user, challenge) do
+    final_section? = is_final_section?(section)
 
     cond do
-      last_section && Challenges.allowed_to_submit?(user) ->
-        submit("Submit", name: "action", value: "submit", class: "usa-button float-right ")
+      final_section? && Challenges.allowed_to_submit?(user) && challenge.status == "draft" ->
+        submit("Submit for Approval",
+          name: "action",
+          value: "submit",
+          class: "btn btn-primary px-5"
+        )
 
-      !last_section ->
+      !final_section? ->
         submit("Next",
           name: "action",
           value: "next",
-          style: "overflow: visible !important; user-select:all;",
-          class: "usa-button btn-testing float-right"
+          class: "btn btn-outline-primary px-5 btn-testing"
         )
 
       true ->
@@ -606,14 +598,14 @@ defmodule Web.ChallengeView do
   def prev_section(section), do: Challenges.prev_section(section)
 
   def remove_update_button(conn, challenge = %{announcement: announcement})
-      when not is_nil(announcement),
-      do:
-        link("Remove update",
-          to: Routes.challenge_path(conn, :remove_announcement, challenge.id),
-          method: :post,
-          class: "btn btn-outline-danger",
-          data: [confirm: "Are you sure you want to remove this update?"]
-        )
+      when not is_nil(announcement) do
+    link("Remove update",
+      to: Routes.challenge_path(conn, :remove_announcement, challenge.id),
+      method: :post,
+      class: "btn btn-outline-danger",
+      data: [confirm: "Are you sure you want to remove this update?"]
+    )
+  end
 
   def remove_update_button(_conn, _challenge), do: nil
 
@@ -842,4 +834,16 @@ defmodule Web.ChallengeView do
         end
     end
   end
+
+  defp confirmation_message(action, %{status: "draft"}),
+    do: "Are you sure you would like to #{action}?"
+
+  defp confirmation_message(action, _),
+    do:
+      "Are you sure you would like to #{action}? By doing so, your changes to this page will #{that_is_the_question(action)} published."
+
+  defp that_is_the_question(:save), do: "be"
+  defp that_is_the_question(action) when action in [:cancel, :exit], do: "not be"
+
+  defp is_final_section?(section), do: section == Enum.at(Challenges.sections(), -1).id
 end

--- a/test/web/controllers/challenge_controller_test.exs
+++ b/test/web/controllers/challenge_controller_test.exs
@@ -454,7 +454,7 @@ defmodule Web.ChallengeControllerTest do
 
       params = %{
         "id" => "#{challenge.id}",
-        "action" => "return_to_review",
+        "action" => "save",
         "challenge" => %{
           "section" => "general",
           "agency_id" => AgencyHelpers.create_agency().id,
@@ -488,7 +488,7 @@ defmodule Web.ChallengeControllerTest do
       assert get_flash(conn, :info) === "Changes saved"
 
       assert redirected_to(conn) ===
-               Routes.challenge_path(conn, :show, challenge.id) <> "#general"
+               Routes.challenge_path(conn, :edit, challenge.id, "general")
     end
 
     test "successfully update a section and go to next section", %{conn: conn} do
@@ -558,7 +558,7 @@ defmodule Web.ChallengeControllerTest do
 
       params = %{
         "id" => "#{challenge.id}",
-        "action" => "return_to_review",
+        "action" => "save",
         "challenge" => %{
           "section" => "general",
           "agency_id" => AgencyHelpers.create_agency().id,
@@ -630,7 +630,7 @@ defmodule Web.ChallengeControllerTest do
                ]
 
       assert redirected_to(conn) ===
-               Routes.challenge_path(conn, :show, challenge.id) <> "#general"
+               Routes.challenge_path(conn, :edit, challenge.id, "general")
     end
   end
 


### PR DESCRIPTION
To stop the accidental reversion of a challenge to draft, the button has been removed. The other buttons have been restyled and in the case of save, repurposed to save and stay in place for further edit.

## Description of changes

## Link to issue
Issue Number: CHAL-1291

# Screenshots / Demo
![draft review](https://user-images.githubusercontent.com/31261713/204097426-200d1fbe-bc02-4b75-a00c-6af3f5a26420.png)
![prevous-next](https://user-images.githubusercontent.com/31261713/204097427-ae547ecc-fb8f-4cd8-93c8-a12919cef93c.png)
![non-draft review section](https://user-images.githubusercontent.com/31261713/204097428-0a81514b-7723-4ca4-b4e2-96e3970353a5.png)
![save-next](https://user-images.githubusercontent.com/31261713/204097429-07458879-ec92-4155-a9d0-d1c569052eb0.png)
