### PR TITLE
Remove copy share link button id parameter in ChallengeTab.js for acc…

### DIFF
--- a/assets/client/src/components/ChallengeTab.js
+++ b/assets/client/src/components/ChallengeTab.js
@@ -30,9 +30,9 @@ export const ChallengeTab = ({label, downloadsLabel, section, challenge, print, 
     <section className="challenge-tab container">
       <div className="challenge-tab__header">
         <span>{label}</span>
-          <div className={copyShareCSS} id="challenge-link">
+          <div className={copyShareCSS}>
             <input disabled aria-hidden="true" id="challenge-link-text" className="opacity-0" defaultValue={window.location.href}/>
-            <button aria-label="Copy share link" id="challenge-link-btn" className="usa-button usa-button--unstyled text-decoration-none" onClick={handleCopyLink}>
+            <button className="usa-button usa-button--unstyled text-decoration-none" onClick={handleCopyLink}>
               <i className="far fa-copy me-1"></i>
               <span>Copy share link</span>
             </button>


### PR DESCRIPTION
## Description of changes
Remove copy share link button id parameter in ChallengeTab.js for accessibility improvement

## Link to issue
Issue Number: 
CHAL-1152

# Checklist
- [x] New functionality is tested and all tests are green
- [x] If you have DB migration, it is a "safe" migration and you've confirmed it can be rolled back.
- [x] If needed, README is up to date
- [x] If applicable, Controllers modified contain appropriate authorization plugs
