### PR TITLE
1. Added a unique ID for the Tooltip target and the challenge-link-te…

### DIFF
--- a/assets/client/src/components/ChallengeTab.js
+++ b/assets/client/src/components/ChallengeTab.js
@@ -4,6 +4,8 @@ import { SectionResources } from "./challenge_tabs/SectionResources"
 
 export const ChallengeTab = ({label, downloadsLabel, section, challenge, print, children}) => {
   const [copyTooltipOpen, setCopyTooltipOpen] = useState(false)
+  const uniqueID = "challenge-link-btn-" + Math.floor(Math.random() * 1000000);
+  const uniqueInputID = "challenge-link-text-" + Math.floor(Math.random() * 1000000);
 
   useEffect(() => {
     const copyTooltipTimeout = setTimeout(() => {
@@ -15,7 +17,7 @@ export const ChallengeTab = ({label, downloadsLabel, section, challenge, print, 
   }, [copyTooltipOpen])
 
   const handleCopyLink = () => {
-    let copyText = document.getElementById("challenge-link-text")
+    let copyText = document.getElementById(uniqueInputID)
 
     copyText.select()
     copyText.setSelectionRange(0,99999)
@@ -27,16 +29,16 @@ export const ChallengeTab = ({label, downloadsLabel, section, challenge, print, 
   const copyShareCSS = print ? "float-right d-none" : "float-right"
 
   return (
-    <section className="challenge-tab container">
-      <div className="challenge-tab__header">
-        <span>{label}</span>
+    <main className="challenge-tab container">
+      <div className="challenge-tab__header" id="challenge-link">
+        <h2>{label}</h2>
           <div className={copyShareCSS}>
-            <input disabled aria-hidden="true" id="challenge-link-text" className="opacity-0" defaultValue={window.location.href}/>
-            <button className="usa-button usa-button--unstyled text-decoration-none" onClick={handleCopyLink}>
+            <input disabled aria-hidden="true" id={uniqueInputID} className="opacity-0" defaultValue={window.location.href}/>
+            <button id={uniqueID} className="usa-button usa-button--unstyled text-decoration-none" onClick={handleCopyLink} aria-label={`Copy share link for ${label}`}>
               <i className="far fa-copy me-1"></i>
               <span>Copy share link</span>
             </button>
-            <Tooltip isOpen={copyTooltipOpen} fade={true} target="challenge-link-btn">Link copied</Tooltip>
+            <Tooltip isOpen={copyTooltipOpen} fade={true} target={uniqueID}>Link copied</Tooltip>
           </div>
       </div>
       <hr/>
@@ -46,6 +48,6 @@ export const ChallengeTab = ({label, downloadsLabel, section, challenge, print, 
         </>
       </section>
       <SectionResources challenge={challenge} section={section} label={downloadsLabel} />
-    </section>
+    </main>
   )
 }


### PR DESCRIPTION
## Description of changes
1. Added a unique ID for the Tooltip target and the challenge-link-text input. 2. Added an aria-label attribute added to the Copy share link button with a more descriptive label. 3. Replaced the section tag with a main tag for the main content area. 4. Used the h2 tag for the label in the tab header.

## Link to issue
Issue Number: 
CHAL-1152

# Checklist
- [x] New functionality is tested and all tests are green
- [x] If you have DB migration, it is a "safe" migration and you've confirmed it can be rolled back.
- [x] If needed, README is up to date
- [x] If applicable, Controllers modified contain appropriate authorization plugs
