### PR TITLE
tune removal of copy share link

### DIFF
--- a/assets/client/src/components/ChallengeTab.js
+++ b/assets/client/src/components/ChallengeTab.js
@@ -41,8 +41,8 @@ export const ChallengeTab = ({ label, downloadsLabel, section, challenge, childr
   return (
     <section className="challenge-tab container">
       <div className="challenge-tab__header">
-        <span>{label}</span>
-        {renderCopyShareButton()}
+        <span>{label}</span>        
+        {/* {renderCopyShareButton()} */}
       </div>
       <hr />
       <section className="challenge-tab__content">
@@ -50,5 +50,5 @@ export const ChallengeTab = ({ label, downloadsLabel, section, challenge, childr
       </section>
       <SectionResources challenge={challenge} section={section} label={downloadsLabel} />
     </section>
-  );
+  )
 };


### PR DESCRIPTION
## Description of changes
Apetty/chal 1152 portal prod remove copy share link

## Link to issue
Issue Number: 
Apetty/chal 1152 portal prod remove copy share link

# Checklist
- [x] New functionality is tested and all tests are green
- [x] If you have DB migration, it is a "safe" migration and you've confirmed it can be rolled back.
- [x] If needed, README is up to date
- [x] If applicable, Controllers modified contain appropriate authorization plugs
