### PR TITLE
Adjust filter full text search to index only on title, tagline, and b…

### DIFF
--- a/assets/client/src/components/ChallengeTiles.js
+++ b/assets/client/src/components/ChallengeTiles.js
@@ -114,22 +114,11 @@ export const ChallengeTiles = ({ data, loading, isArchived, selectedYear, handle
         }
 
         if (keyword) {
-          const searchFields = ["agency_name", "title", "tagline"];
-
+          const searchFields = ["title", "tagline", "brief_description"];
           filtered = filtered.filter((challenge) => {
-            // Search in agency_name, title, and tagline fields
+            // Search in title, tagline, and brief_description fields
             for (const field of searchFields) {
               if (challenge[field] && challenge[field].toLowerCase().includes(keyword.toLowerCase())) {
-                return true;
-              }
-            }
-
-            // Search in how_to_enter and judging_criteria fields inside phases
-            for (const phase of challenge.phases) {
-              if (phase.how_to_enter && phase.how_to_enter.toLowerCase().includes(keyword.toLowerCase())) {
-                return true;
-              }
-              if (phase.judging_criteria && phase.judging_criteria.toLowerCase().includes(keyword.toLowerCase())) {
                 return true;
               }
             }

--- a/lib/web/views/api/challenge_view.ex
+++ b/lib/web/views/api/challenge_view.ex
@@ -25,6 +25,7 @@ defmodule Web.Api.ChallengeView do
       uuid: challenge.uuid,
       title: challenge.title,
       tagline: challenge.tagline,
+      brief_description: challenge.brief_description,
       custom_url: challenge.custom_url,
       external_url: challenge.external_url,
       agency_name: ChallengeView.agency_name(challenge),


### PR DESCRIPTION
## Description of changes
Adjust filter full text search to index only on title, tagline, and brief_description

## Link to issue
Issue Number: 
CHAL-1099

# Checklist
- [x] New functionality is tested and all tests are green
- [x] If you have DB migration, it is a "safe" migration and you've confirmed it can be rolled back.
- [x] If needed, README is up to date
- [x] If applicable, Controllers modified contain appropriate authorization plugs
