### PR TITLE
add no proxy for login.gov to verify that

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -21,7 +21,7 @@ applications:
     HTTP_PROXY: https://user:password@challengecproxy.apps.internal:61443
     https_proxy: https://user:password@challengecproxy.apps.internal:61443
     http_proxy: https://user:password@challengecproxy.apps.internal:61443
-    NO_PROXY: '*.repo.hex.pm'
+    NO_PROXY: '*.repo.hex.pm *idp.int.identitysandbox.gov'
     HEX_UNSAFE_HTTPS: "1"
     HOST: challenge-portal-dev.app.cloud.gov
     LOGIN_PRIVATE_KEY_PATH: dev_key.pem


### PR DESCRIPTION
## Description of changes
with Login.gov errors from auth, this is an attempt to isolate the issue to just login.gov and hopefully the rest of the portal works
## Link to issue
Issue Number: 
CHAL-1662
# Screenshots / Demo
_Include steps a user would need to make in order to exercise the new functionality._

# Checklist
- [ ] New functionality is tested and all tests are green
- [ ] If you have DB migration, it is a "safe" migration and you've confirmed it can be rolled back.
- [ ] If needed, README is up to date
- [ ] If applicable, Controllers modified contain appropriate authorization plugs
