### PR TITLE
Move to environment variables in circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,6 +145,11 @@ jobs:
     parallelism: 1
     docker:
       - image: cimg/node:10.24.1
+        environment:
+          HTTPS_PROXY: CADDY_PROXY
+          HTTP_PROXY: CADDY_PROXY
+          https_proxy: CADDY_PROXY
+          http_proxy: CADDY_PROXY
     steps:
       - checkout
       - attach_workspace:
@@ -153,10 +158,6 @@ jobs:
       - run: echo -e $DEV_PUBLIC_CERT > dev_cert.pem
       - run: echo 'export CF_PASSWORD=$CF_PASSWORD_DEV' >> $BASH_ENV
       - run: echo 'export CF_USERNAME=$CF_USERNAME_DEV' >> $BASH_ENV
-      - run: echo 'export CADDY_PROXY="HTTPS_PROXY"' >> $BASH_ENV
-      - run: echo 'export CADDY_PROXY="HTTP_PROXY"' >> $BASH_ENV
-      - run: echo 'export CADDY_PROXY="https_proxy"' >> $BASH_ENV
-      - run: echo 'export CADDY_PROXY="http_proxy"' >> $BASH_ENV
       - run:
           name: Install Cloud Foundry CLI
           command: |


### PR DESCRIPTION
## Description of changes
Attempt to move the secrets from pushing to bash to having them built in with circleci environments on the image
## Link to issue
Issue Number: 
CHAL-1661
# Screenshots / Demo
_Include steps a user would need to make in order to exercise the new functionality._

# Checklist
- [ ] New functionality is tested and all tests are green
- [ ] If you have DB migration, it is a "safe" migration and you've confirmed it can be rolled back.
- [ ] If needed, README is up to date
- [ ] If applicable, Controllers modified contain appropriate authorization plugs
