### PR TITLE
change the export challenge to name the files as uuid.ext

### DIFF
--- a/lib/challenge_gov/submissions/submission_export_worker.ex
+++ b/lib/challenge_gov/submissions/submission_export_worker.ex
@@ -82,9 +82,10 @@ defmodule ChallengeGov.Submissions.SubmissionExportWorker do
         {:ok, document_download} = Storage.download(SubmissionDocuments.document_path(document))
 
         document_path = tmp_file_directory <> "submissions/#{submission.id}/"
-        File.mkdir_p(document_path)
-        document_filename = "#{DocumentView.filename(document)}#{document.extension}"
-
+        File.mkdir_p(document_path)        
+        # Use the `key` field from the document, which is a unique UUID
+        document_filename = "#{document.key}#{document.extension}"
+        #document_filename = "#{DocumentView.filename(document)}#{document.extension}"
         File.cp!(document_download, document_path <> document_filename)
         File.rm(document_download)
       end)

--- a/lib/challenge_gov/submissions/submission_export_worker.ex
+++ b/lib/challenge_gov/submissions/submission_export_worker.ex
@@ -82,10 +82,10 @@ defmodule ChallengeGov.Submissions.SubmissionExportWorker do
         {:ok, document_download} = Storage.download(SubmissionDocuments.document_path(document))
 
         document_path = tmp_file_directory <> "submissions/#{submission.id}/"
-        File.mkdir_p(document_path)        
-        # Use the `key` field from the document, which is a unique UUID
+        File.mkdir_p(document_path)
+        # document_filename = "#{DocumentView.filename(document)}#{document.extension}"
         document_filename = "#{document.key}#{document.extension}"
-        #document_filename = "#{DocumentView.filename(document)}#{document.extension}"
+
         File.cp!(document_download, document_path <> document_filename)
         File.rm(document_download)
       end)


### PR DESCRIPTION
## Description of changes

This commit modifies the file naming mechanism in the ZIP export process by using the `key` UUID field as the file name instead of the user-provided name. The change has been made to ensure filesystem compatibility, as well as to avoid issues with special characters and duplicated file names.

Files within the export are now named with their unique identifier, ensuring no naming collisions and simplifying file management. To maintain user readability and file identification, a future update may introduce a manifest mapping UUIDs to original names.

Changes made in:
- `SubmissionExportWorker` module - Adjusted export logic to use `document.key` for file naming.

## Link to issue
Issue Number: CHAL-1818

# Screenshots / Demo
To exercise the new functionality:
1. Navigate to the submissions export page.
2. Initiate an export of submission files.
3. Once the ZIP file is downloaded, verify that the files contained are named using their UUIDs.
 applicable