### PR TITLE
remove unused color_stream dependency with compilation errors

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -44,7 +44,6 @@ defmodule ChallengeGov.MixProject do
       {:browser, "~> 0.4.4"},
       {:cors_plug, "~> 3.0"},
       {:excoveralls, "~> 0.10", only: :test},
-      {:color_stream, "~> 0.0.1"},
       {:credo, "~> 1.4", only: [:dev, :test], runtime: false},
       {:credo_contrib, "~> 0.2", only: [:dev, :test], runtime: false},
       {:credo_envvar, "~> 0.1", only: [:dev, :test], runtime: false},

--- a/mix.lock
+++ b/mix.lock
@@ -6,7 +6,6 @@
   "bunt": {:hex, :bunt, "0.2.1", "e2d4792f7bc0ced7583ab54922808919518d0e57ee162901a16a1b6664ef3b14", [:mix], [], "hexpm", "a330bfb4245239787b15005e66ae6845c9cd524a288f0d141c148b02603777a5"},
   "castore": {:hex, :castore, "0.1.22", "4127549e411bedd012ca3a308dede574f43819fe9394254ca55ab4895abfa1a2", [:mix], [], "hexpm", "c17576df47eb5aa1ee40cc4134316a99f5cad3e215d5c77b8dd3cfef12a22cac"},
   "certifi": {:hex, :certifi, "2.9.0", "6f2a475689dd47f19fb74334859d460a2dc4e3252a3324bd2111b8f0429e7e21", [:rebar3], [], "hexpm", "266da46bdb06d6c6d35fde799bcb28d36d985d424ad7c08b5bb48f5b5cdd4641"},
-  "color_stream": {:hex, :color_stream, "0.0.2", "400fe4b5efe3fcaf723d5bf2ba02f868b92b16b90b0bc99ebcf515a5678412ae", [:mix], [], "hexpm", "b1181f32b310311016006f4f8d52b3418d1af6f06e71903daabafdcaa602a29d"},
   "combine": {:hex, :combine, "0.10.0", "eff8224eeb56498a2af13011d142c5e7997a80c8f5b97c499f84c841032e429f", [:mix], [], "hexpm", "1b1dbc1790073076580d0d1d64e42eae2366583e7aecd455d1215b0d16f2451b"},
   "comeonin": {:hex, :comeonin, "5.3.2", "5c2f893d05c56ae3f5e24c1b983c2d5dfb88c6d979c9287a76a7feb1e1d8d646", [:mix], [], "hexpm", "d0993402844c49539aeadb3fe46a3c9bd190f1ecf86b6f9ebd71957534c95f04"},
   "connection": {:hex, :connection, "1.1.0", "ff2a49c4b75b6fb3e674bfc5536451607270aac754ffd1bdfe175abe4a6d7a68", [:mix], [], "hexpm", "722c1eb0a418fbe91ba7bd59a47e28008a189d47e37e0e7bb85585a016b2869c"},


### PR DESCRIPTION
### Description

Removes the ColorStream module. This is currently unused and causes a compilation error on certain versions of Elixir. Probably best to remove it since it is not referenced anywhere in the codebase.

### Related Issues

[Reference any related issues, if applicable.]

### Changes Made

- removed the dep from mix.exs and mix.lock

### Screenshots (if applicable)

[Include screenshots to visually demonstrate changes, if relevant.]

# Checklist
- [ ] PR is assigned to a project: Challenge_gov Board
- [ ] PR is assigned to a milestone: current sprint
- [ ] PR is assigned a reviewer, and requires code review and approval by a teammate
- [ ] New functionality is tested and all tests are green
- [ ] I have added unit tests for new functionality or updated existing tests for changes.
- [ ] I have updated the documentation/README accordingly, if necessary.
- [ ] If you have DB migration, it is a "safe" migration and you've confirmed it can be rolled back.
- [ ] If applicable, Controllers modified contain appropriate authorization plugs
- [ ] This PR has been reviewed by at least one other team member.

