### PR TITLE
configure Nix to use default node version 20.15.1

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -23,7 +23,7 @@ let
     pkgs.postgresql
 
     pkgs.elixir_1_16
-    pkgs.nodejs_18
+    pkgs.nodejs
     pkgs.yarn
     pkgs.license_finder
 


### PR DESCRIPTION
### Description

Had an issue running the app locally. It was fixed by updating the Nix node version to use the default version (currently 20.15.1). 

### Related Issues

### Changes Made

- `shell.nix` (only affects dev machines that are using Nix)

# Checklist
- [x] PR is assigned to a project: Challenge_gov Board
- [x] PR is assigned to a milestone: current sprint
- [ ] ~~GH issues are assigned to the PR (under Development section on the right hand side)~~
- [ ] PR is assigned a reviewer, and requires code review and approval by a teammate
- [ ] New functionality is tested and all tests are green
- [ ] ~~I have added unit tests for new functionality or updated existing tests for changes.~~
- [ ] ~~I have updated the documentation/README accordingly, if necessary.~~
- [ ] ~~If you have DB migration, it is a "safe" migration and you've confirmed it can be rolled back.~~
- [ ] ~~If applicable, Controllers modified contain appropriate authorization plugs~~
- [ ] This PR has been reviewed by at least one other team member.

