### PR TITLE
add cookie option same_site: "Lax"

### DIFF
--- a/lib/web/endpoint.ex
+++ b/lib/web/endpoint.ex
@@ -11,6 +11,7 @@ defmodule Web.Endpoint do
   @session_options [
     store: :cookie,
     key: "_challenge_gov_key",
+    same_site: "Lax",
     signing_salt: "+S7HWPoL"
   ]
 


### PR DESCRIPTION
### Description
#24 - add same_site cookie option for session cookies