### PR TITLE
1390 non gov access to information challenge managers from staging

### DIFF
--- a/lib/challenge_gov/challenges.ex
+++ b/lib/challenge_gov/challenges.ex
@@ -755,13 +755,9 @@ defmodule ChallengeGov.Challenges do
     end
   end
 
-  def validate_gov_mil?(email) do
-    String.ends_with?(email, [".gov", ".mil"])
-  end
-
   def allowed_to_view_submission(user, challenge) do
     if user.role == "challenge_manager" do
-      if validate_gov_mil?(user.email) do
+      if Security.validate_gov_mil?(user.email) do
         {:ok, challenge}
       else
         {:error, :not_permitted}
@@ -770,7 +766,7 @@ defmodule ChallengeGov.Challenges do
   end
 
   def is_allowed_to_view_submission?(user = %{role: "challenge_manager"}),
-    do: validate_gov_mil?(user.email)
+    do: Security.validate_gov_mil?(user.email)
 
   def is_allowed_to_view_submission?(user = %{role: "super_admin"}), do: true
 
@@ -1315,19 +1311,6 @@ defmodule ChallengeGov.Challenges do
 
   defp maybe_send_submission_confirmation(_challenge, _action), do: nil
 
-  # check role challenge_manager & .gov or .mil email account
-  defp is_challenge_manager_ng(user = %{role: "challenge_manager"}) do
-    if validate_gov_mil?(user.email) do
-      user.role
-    else
-      "challenge_manager_ng"
-    end
-  end
-
-  defp is_challenge_manager_ng(user = %{role: _}) do
-    user.role
-  end
-
   # BOOKMARK: Security log functions
   defp add_to_security_log_multi(multi, user, type, remote_ip, details \\ nil) do
     Ecto.Multi.run(multi, :log, fn _repo, %{challenge: challenge} ->
@@ -1338,7 +1321,7 @@ defmodule ChallengeGov.Challenges do
   def add_to_security_log(user, challenge, type, remote_ip, details \\ nil) do
     SecurityLogs.track(%{
       originator_id: user.id,
-      originator_role: is_challenge_manager_ng(user),
+      originator_role: user.role,
       originator_identifier: user.email,
       originator_remote_ip: remote_ip,
       target_id: challenge.id,

--- a/lib/challenge_gov/security.ex
+++ b/lib/challenge_gov/security.ex
@@ -213,19 +213,12 @@ defmodule ChallengeGov.Security do
   # functions to control non-gov challenge manager
   def intercept_challenge_manager_ng(original_track) do
     %{
-      originator_id: original_track.originator_id,
-      originator_role:
-        is_challenge_manager_ng(
-          original_track.originator_role,
-          original_track.originator_identifier
-        ),
-      originator_identifier: original_track.originator_identifier,
-      originator_remote_ip: original_track.originator_remote_ip,
-      target_id: original_track.target_id,
-      target_type: original_track.target_type,
-      target_identifier: original_track.target_identifier,
-      action: original_track.action,
-      details: original_track.details
+      original_track
+      | originator_role:
+          is_challenge_manager_ng(
+            original_track.originator_role,
+            original_track.originator_identifier
+          )
     }
   end
 

--- a/lib/challenge_gov/security.ex
+++ b/lib/challenge_gov/security.ex
@@ -209,4 +209,40 @@ defmodule ChallengeGov.Security do
     |> String.split(",")
     |> Enum.map(&String.trim/1)
   end
+
+  # functions to control non-gov challenge manager
+  def intercept_challenge_manager_ng(original_track) do
+    %{
+      originator_id: original_track.originator_id,
+      originator_role:
+        is_challenge_manager_ng(
+          original_track.originator_role,
+          original_track.originator_identifier
+        ),
+      originator_identifier: original_track.originator_identifier,
+      originator_remote_ip: original_track.originator_remote_ip,
+      target_id: original_track.target_id,
+      target_type: original_track.target_type,
+      target_identifier: original_track.target_identifier,
+      action: original_track.action,
+      details: original_track.details
+    }
+  end
+
+  # check role challenge_manager & .gov or .mil email account
+  def is_challenge_manager_ng(originator_role, originator_identifier) do
+    if originator_role == "challenge_manager" do
+      if validate_gov_mil?(originator_identifier) do
+        originator_role
+      else
+        "challenge_manager_ng"
+      end
+    else
+      originator_role
+    end
+  end
+
+  def validate_gov_mil?(email) do
+    String.ends_with?(email, [".gov", ".mil"])
+  end
 end

--- a/lib/challenge_gov/security_logs.ex
+++ b/lib/challenge_gov/security_logs.ex
@@ -15,6 +15,8 @@ defmodule ChallengeGov.SecurityLogs do
   def track(params) do
     Logger.info("Audit event #{params[:action]}", log_type: "audit", params: params)
 
+    params = Security.intercept_challenge_manager_ng(original_track = params)
+
     %SecurityLog{}
     |> SecurityLog.changeset(params)
     |> Repo.insert()
@@ -55,7 +57,7 @@ defmodule ChallengeGov.SecurityLogs do
         action: "session_duration",
         details: %{duration: duration},
         originator_id: user.id,
-        originator_role: user.role,
+        originator_role: Security.is_challenge_manager_ng(user.role, user.emailcle),
         originator_identifier: user.email,
         originator_remote_ip: remote_ip
       })

--- a/lib/challenge_gov/security_logs.ex
+++ b/lib/challenge_gov/security_logs.ex
@@ -57,7 +57,7 @@ defmodule ChallengeGov.SecurityLogs do
         action: "session_duration",
         details: %{duration: duration},
         originator_id: user.id,
-        originator_role: Security.is_challenge_manager_ng(user.role, user.emailcle),
+        originator_role: Security.is_challenge_manager_ng(user.role, user.email),
         originator_identifier: user.email,
         originator_remote_ip: remote_ip
       })

--- a/lib/challenge_gov/submissions.ex
+++ b/lib/challenge_gov/submissions.ex
@@ -301,22 +301,9 @@ defmodule ChallengeGov.Submissions do
     submission.manager_id && !submission.review_verified
   end
 
-  # check role challenge_manager & .gov or .mil email account
-  defp is_challenge_manager_ng(user = %{role: "challenge_manager"}) do
-    if validate_gov_mil?(user.email) do
-      user.role
-    else
-      "challenge_manager_ng"
-    end
-  end
-
-  def validate_gov_mil?(email) do
-    String.ends_with?(email, [".gov", ".mil"])
-  end
-
   def allowed_to_view_submission(user, submission) do
     if user.role == "challenge_manager" do
-      if validate_gov_mil?(user.email) do
+      if Security.validate_gov_mil?(user.email) do
         {:ok, submission}
       else
         {:error, :not_permitted}
@@ -325,17 +312,13 @@ defmodule ChallengeGov.Submissions do
   end
 
   def is_allowed_to_view_submission?(user = %{role: "challenge_manager"}),
-    do: validate_gov_mil?(user.email)
+    do: Security.validate_gov_mil?(user.email)
 
   def is_allowed_to_view_submission?(user = %{role: "super_admin"}), do: true
 
   def is_allowed_to_view_submission?(user = %{role: "admin"}), do: true
 
   def is_allowed_to_view_submission?(user = %{role: "solver"}), do: true
-
-  defp is_challenge_manager_ng(user = %{role: _}) do
-    user.role
-  end
 
   defp send_submission_review_email(user, phase, submission) do
     user
@@ -542,7 +525,7 @@ defmodule ChallengeGov.Submissions do
   defp add_to_security_log(user, submission, type, remote_ip, details \\ nil) do
     SecurityLogs.track(%{
       originator_id: user.id,
-      originator_role: is_challenge_manager_ng(user),
+      originator_role: user.role,
       originator_identifier: user.email,
       originator_remote_ip: remote_ip,
       target_id: submission.id,


### PR DESCRIPTION
…s on Security and Security Logs.

### Description

Improve the challenge manager and non-gov challenger manager log tracking. 

### Related Issues

challenge_manager role not fully tracked as challenge_manager_ng for non-gov accounts.

### Changes Made

Update Security and Security Logs centralizing the functions handling tracking and non-gov detection.
Updating Challenge and Submission modules by referencing non-gov related functions to the Security module.

### Screenshots (if applicable)

NA

# Checklist
- [x] PR is assigned to a project: Challenge_gov Board
- [x] PR is assigned to a milestone: current sprint
- [x] GH issues are assigned to the PR (under Development section on the right hand side)
- [x] PR is assigned a reviewer, and requires code review and approval by a teammate
~- [] New functionality is tested and all tests are green~
~- [] I have added unit tests for new functionality or updated existing tests for changes.~
~- [ ] I have updated the documentation/README accordingly, if necessary.~
~- [ ] If you have DB migration, it is a "safe" migration and you've confirmed it can be rolled back.~
~- [ ] If applicable, Controllers modified contain appropriate authorization plugs~
- [x] This PR has been reviewed by at least one other team member.
