### PR TITLE
Fix bug - change method attribute

### DIFF
--- a/lib/web/router.ex
+++ b/lib/web/router.ex
@@ -133,7 +133,7 @@ defmodule Web.Router do
     )
 
     post("/challenges/:id/create_announcement", ChallengeController, :create_announcement)
-    post("/challenges/:id/remove_announcement", ChallengeController, :remove_announcement)
+    get("/challenges/:id/remove_announcement", ChallengeController, :remove_announcement)
 
     resources("/challenges/:id/submissions/export", SubmissionExportController,
       only: [:index, :create]

--- a/lib/web/views/challenge_view.ex
+++ b/lib/web/views/challenge_view.ex
@@ -648,7 +648,7 @@ defmodule Web.ChallengeView do
       when not is_nil(announcement) do
     link("Remove update",
       to: Routes.challenge_path(conn, :remove_announcement, challenge.id),
-      method: :post,
+      method: :get,
       class: "usa-button usa-button--secondary",
       data: [confirm: "Are you sure you want to remove this update?"]
     )


### PR DESCRIPTION
### Description

Fixing a bug on deleting a challenge announcement banner.

### Related Issues

on deleting a challenge announcement banner.

### Changes Made

- Change Post Method by Get.

### Screenshots (if applicable)

<img width="990" alt="Evidence removal 1" src="https://github.com/user-attachments/assets/4e5de154-d58a-4006-a757-43350b33891c" />
<img width="721" alt="Evidence removal 2" src="https://github.com/user-attachments/assets/898fd892-d564-45b1-8526-25beca4d08f3" />


# Checklist
- [x] PR is assigned to a project: Challenge_gov Board
- [x] PR is assigned to a milestone: current sprint
- [x] GH issues are assigned to the PR (under Development section on the right hand side)
- [x] PR is assigned a reviewer, and requires code review and approval by a teammate
- [x] New functionality is tested and all tests are green
~- [] I have added unit tests for new functionality or updated existing tests for changes.
~- [ ] I have updated the documentation/README accordingly, if necessary.~
~- [ ] If you have DB migration, it is a "safe" migration and you've confirmed it can be rolled back.~
~- [ ] If applicable, Controllers modified contain appropriate authorization plugs~
- [x] This PR has been reviewed by at least one other team member.
- [x] Build has been approved for deployment in CircleCI.

