### PR TITLE
Add New User Status evaluator_role_requested

### DIFF
--- a/lib/challenge_gov/accounts/user.ex
+++ b/lib/challenge_gov/accounts/user.ex
@@ -39,7 +39,8 @@ defmodule ChallengeGov.Accounts.User do
     "suspended",
     "revoked",
     "deactivated",
-    "decertified"
+    "decertified",
+    "evaluator_role_requested"
   ]
 
   schema "users" do


### PR DESCRIPTION
### Description
Relevant tickets: [Challenge_platform User Story 287](https://github.com/GSA/Challenge_platform/issues/287) & [PR 287](https://github.com/GSA/Challenge_platform/pull/341) 

This change is required to keep the Phoenix and Rails apps in sync.

An additional user status was added in the Rails app ('evaluator_role_requested'). 
This user status is for existing users that need their role changed. 
The user's role will need to be changed to 'evaluator' by an admin, then their status becomes 'Available' for assignment to submissions. 

### Related Issues

Related tickets: [Challenge_platform User Story 287](https://github.com/GSA/Challenge_platform/issues/287) & [PR 287](https://github.com/GSA/Challenge_platform/pull/341) 

### Changes Made

- Added a new user status `evaluator_role_requested` to align with the user statuses in the Rails app 

### Screenshots (if applicable)

There's a UI demo in [PR 287](https://github.com/GSA/Challenge_platform/pull/341) showing the use of the new user status. 

# Checklist
- [ ] PR is assigned to a project: Challenge_gov Board
- [ ] PR is assigned to a milestone: current sprint
- [ ] GH issues are assigned to the PR (under Development section on the right hand side)
- [ ] PR is assigned a reviewer, and requires code review and approval by a teammate
- [ ] New functionality is tested and all tests are green
- [ ] I have added unit tests for new functionality or updated existing tests for changes.
- [ ] I have updated the documentation/README accordingly, if necessary.
- [ ] If you have DB migration, it is a "safe" migration and you've confirmed it can be rolled back.
- [ ] If applicable, Controllers modified contain appropriate authorization plugs
- [ ] This PR has been reviewed by at least one other team member.
- [ ] Build has been approved for deployment in CircleCI.

