### PR TITLE
Add user status evaluator_role_requested to admin action required

### DIFF
--- a/lib/challenge_gov/accounts.ex
+++ b/lib/challenge_gov/accounts.ex
@@ -71,6 +71,13 @@ defmodule ChallengeGov.Accounts do
     |> Repo.all()
   end
 
+  def all_evaluator_role_requested() do
+    User
+    |> where([u], u.status == "evaluator_role_requested")
+    |> order_by([u], [{:asc, u.inserted_at}])
+    |> Repo.all()
+  end
+
   @doc """
   Get all accounts
   """

--- a/lib/web/controllers/user_controller.ex
+++ b/lib/web/controllers/user_controller.ex
@@ -25,6 +25,7 @@ defmodule Web.UserController do
     pending_users = Accounts.all_pending()
     reactivation_users = Accounts.all_reactivation()
     requesting_recertification = Accounts.requesting_recertification()
+    evaluator_role_requested = Accounts.all_evaluator_role_requested()
 
     conn
     |> assign(:user, current_user)
@@ -32,7 +33,8 @@ defmodule Web.UserController do
     |> assign(:users, users)
     |> assign(
       :users_requiring_action,
-      pending_users ++ reactivation_users ++ requesting_recertification
+      pending_users ++
+        reactivation_users ++ requesting_recertification ++ evaluator_role_requested
     )
     |> assign(:filter, filter)
     |> assign(:sort, sort)

--- a/lib/web/views/user_view.ex
+++ b/lib/web/views/user_view.ex
@@ -116,6 +116,13 @@ defmodule Web.UserView do
     </svg>&nbsp;</span>Pending</span>
     """
 
+  def status("evaluator_role_requested"),
+    do: ~E"""
+     <span style="color:#E5A002"><span><svg class="usa-icon" aria-hidden="true" focusable="false" role="img">
+     <use xlink:href="/assets/img/sprite.svg#person"></use>
+    </svg>&nbsp;</span>Evaluator Role Requested</span>
+    """
+
   def status("deactivated"),
     do: ~E"""
      <span style="color:#B50808"><span><svg class="usa-icon" aria-hidden="true" focusable="false" role="img">


### PR DESCRIPTION
### Description

Add new valid user status `evaluator_role_requested` to show up in admin action required and give it a yellow status color. 

_Given an existing user with status `evaluator_role_requested`, when assigned to a challenge phase in the Rails app,
then that user shows up in the Phoenix app as admin action required and the admin can activate that user._ 

### Related Issues

[#287](https://github.com/GSA/Challenge_platform/pull/341) 

### Changes Made

- Include `evaluator_role_requested` user status to statuses of users_requiring_action
- Add yellow status to 'Evaluator Role Requested' 

### Screenshots (if applicable)

![evaluator role requested](https://github.com/user-attachments/assets/952e3cc0-e566-4423-a775-2af54770edbf)


# Checklist
- [ ] PR is assigned to a project: Challenge_gov Board
- [ ] PR is assigned to a milestone: current sprint
- [ ] GH issues are assigned to the PR (under Development section on the right hand side)
- [ ] PR is assigned a reviewer, and requires code review and approval by a teammate
- [ ] New functionality is tested and all tests are green
- [ ] I have added unit tests for new functionality or updated existing tests for changes.
- [ ] I have updated the documentation/README accordingly, if necessary.
- [ ] If you have DB migration, it is a "safe" migration and you've confirmed it can be rolled back.
- [ ] If applicable, Controllers modified contain appropriate authorization plugs
- [ ] This PR has been reviewed by at least one other team member.
- [ ] Build has been approved for deployment in CircleCI.

