### PR TITLE
Add dev account email login

### DIFF
--- a/lib/web/templates/page/dev_accounts.html.eex
+++ b/lib/web/templates/page/dev_accounts.html.eex
@@ -32,7 +32,6 @@
   <div>
     <h1>Challenge Manager Accounts</h1>
     <%= button("Challenge Manager Active", to: Routes.dev_accounts_page_path(@conn, :dev_account_sign_in, email: "challenge_manager_active@example.gov"), method: :post, class: "usa-button") %>
-    <%= button("Challenge Manager Alejandro@gmail.com", to: Routes.dev_accounts_page_path(@conn, :dev_account_sign_in, email: "alejandro.donis@gmail.com"), method: :post, class: "usa-button") %>
     <%= button("Pending", to: Routes.dev_accounts_page_path(@conn, :dev_account_sign_in, email: "challenge_manager_pending@example.com"), method: :post, class: "usa-button") %>
     <%= button("Suspended", to: Routes.dev_accounts_page_path(@conn, :dev_account_sign_in, email: "challenge_manager_suspended@example.com"), method: :post, class: "usa-button") %>
     <%= button("Revoked", to: Routes.dev_accounts_page_path(@conn, :dev_account_sign_in, email: "challenge_manager_revoked@example.com"), method: :post, class: "usa-button") %>

--- a/lib/web/templates/page/dev_accounts.html.eex
+++ b/lib/web/templates/page/dev_accounts.html.eex
@@ -1,5 +1,15 @@
 <div class="grid-container">
   <div>
+    <h1>By Email</h1>
+    <form action="<%= Routes.dev_accounts_page_path(@conn, :dev_account_sign_in) %>" accept-charset="UTF-8" method="post">
+      <input type="hidden" name="_csrf_token" value="<%= Phoenix.Controller.get_csrf_token() %>" autocomplete="off">
+      <label for="email">Email</label>
+      <input type="text" name="email" id="email">
+      <input type="submit" name="commit" value="Dev Login" data-disable-with="Dev Login">
+    </form>
+  </div>
+  <br/>
+  <div>
     <h1>Super Admin Accounts</h1>
     <%= button("Active", to: Routes.dev_accounts_page_path(@conn, :dev_account_sign_in, email: "super_admin_active@example.com"), method: :post, class: "usa-button") %>
     <%= button("Pending", to: Routes.dev_accounts_page_path(@conn, :dev_account_sign_in, email: "super_admin_pending@example.com"), method: :post, class: "usa-button") %>
@@ -50,4 +60,4 @@
     <%= button("Deactivated", to: Routes.dev_accounts_page_path(@conn, :dev_account_sign_in, email: "solver_deactivated@example.com"), method: :post, class: "usa-button") %>
     <%= button("Decertified", to: Routes.dev_accounts_page_path(@conn, :dev_account_sign_in, email: "solver_decertified@example.com"), method: :post, class: "usa-button") %>
   </div>
-<div>
+</div>


### PR DESCRIPTION
### Description

Adds an email input field to login directly as any user under `/dev_accounts` in case a login button doesn't exist for that user.

### Changes Made

- Updates the `dev_accounts.html.eex` template, which is only available in :dev and :test modes.

### Screenshots (if applicable)
![Screenshot 2025-03-24 at 3 22 49 PM](https://github.com/user-attachments/assets/1cfd5371-c7d3-4761-99f6-dee6174feb6d)

# Checklist
- [x] PR is assigned to a project: Challenge_gov Board
- [x] PR is assigned to a milestone: current sprint
- [ ] ~GH issues are assigned to the PR (under Development section on the right hand side)~
- [x] PR is assigned a reviewer, and requires code review and approval by a teammate
- [x] New functionality is tested and all tests are green
- [ ] ~I have added unit tests for new functionality or updated existing tests for changes.~
- [x] I have updated the documentation/README accordingly, if necessary.
- [ ] ~If you have DB migration, it is a "safe" migration and you've confirmed it can be rolled back.~
- [x] If applicable, Controllers modified contain appropriate authorization plugs
- [ ] This PR has been reviewed by at least one other team member.
- [ ] Build has been approved for deployment in CircleCI.

