### PR TITLE
[175] Activity on either app resets the timeout

### DIFF
--- a/lib/web/controllers/api/session_controller.ex
+++ b/lib/web/controllers/api/session_controller.ex
@@ -46,6 +46,19 @@ defmodule Web.Api.SessionController do
     verify_external_login_request(conn)
   end
 
+  def external_renew_session(conn, _opts) do
+    login_secret = conn |> get_req_header("login-secret") |> List.first()
+
+    if login_secret == System.get_env("LOGIN_SECRET") do
+      conn
+      |> put_session(:session_timeout_at, new_session_timeout_at(Security.timeout_interval()))
+      |> configure_session(renew: true)
+      |> send_resp(200, "Success")
+    else
+      send_resp(conn, 401, "Unauthorized")
+    end
+  end
+
   defp verify_external_login_request(conn) do
     login_secret = conn |> get_req_header("login-secret") |> List.first()
     remote_ip = conn |> get_req_header("remote-ip") |> List.first()

--- a/lib/web/router.ex
+++ b/lib/web/router.ex
@@ -229,6 +229,7 @@ defmodule Web.Router do
     post("/phase_winners/:id/upload_winner_image", WinnerController, :upload_image)
 
     post("/session/renew", SessionController, :check_session_timeout)
+    post("/session/external_renew", SessionController, :external_renew_session)
     post("/session/logout", SessionController, :logout_user)
   end
 


### PR DESCRIPTION
### Description

[Provide a brief description of the changes implemented in this pull request.]

### Related Issues

[Challenge Platform #175](https://github.com/GSA/Challenge_platform/issues/175)

[Reference any related issues, if applicable.]

### Changes Made

- [List the specific changes made in bullet points.]

### Screenshots (if applicable)

[Include screenshots to visually demonstrate changes, if relevant.]

# Checklist
- [ ] PR is assigned to a project: Challenge_gov Board
- [ ] PR is assigned to a milestone: current sprint
- [ ] GH issues are assigned to the PR (under Development section on the right hand side)
- [ ] PR is assigned a reviewer, and requires code review and approval by a teammate
- [ ] New functionality is tested and all tests are green
- [ ] I have added unit tests for new functionality or updated existing tests for changes.
- [ ] I have updated the documentation/README accordingly, if necessary.
- [ ] If you have DB migration, it is a "safe" migration and you've confirmed it can be rolled back.
- [ ] If applicable, Controllers modified contain appropriate authorization plugs
- [ ] This PR has been reviewed by at least one other team member.
- [ ] Build has been approved for deployment in CircleCI.

